### PR TITLE
Parameter Resolution Cleanup + Symbol Type Safety

### DIFF
--- a/docs/proposals/PARAMETER_RESOLUTION_CLEANUP.md
+++ b/docs/proposals/PARAMETER_RESOLUTION_CLEANUP.md
@@ -36,7 +36,7 @@ Four implementation steps, each self-contained, compilable, and testable.
 
 ### Dependencies
 
-```
+```text
 Step 1 (Parameter Rename) ─┬─→ Step 3 (Call Validation) ─→ Step 4 (Parameter Resolution)
 Step 2 (Alias Type Split) ─┘
 ```

--- a/docs/proposals/PARAMETER_RESOLUTION_CLEANUP.md
+++ b/docs/proposals/PARAMETER_RESOLUTION_CLEANUP.md
@@ -1,10 +1,24 @@
-# Parameter Resolution Cleanup + Alias Type Safety
+# Parameter Resolution Cleanup + Symbol Type Safety
 
 ## Problem
 
-Two architectural issues in the compiler's type system and symbol resolution:
+Four architectural issues in the compiler's type system and symbol resolution:
 
-### 1. Duplicate Scope Mechanism for Parameters
+### 1. Misleading Symbol Type Names
+
+`Symbol.Type.VARIABLE` and `LOCATION_VARIABLE` are used exclusively for procedure parameters. "Variable" implies a named storage location (like `int x`); "parameter" is what they actually are.
+
+### 2. Module Aliases Share Symbol Type with Register Aliases
+
+`.IMPORT` and `.REQUIRE` aliases (ImportSymbolCollector, RequireSymbolCollector) are registered as `Symbol.Type.ALIAS` — the same type used by `.REG` register aliases. InstructionAnalysisHandler accepts `ALIAS` in register positions without checking whether the symbol is actually a register alias. A module alias used as an instruction argument (e.g., `SETI MATH 42` where MATH is an `.IMPORT` alias) passes Phase 4 analysis but fails late at Phase 10 linking. Module aliases need their own Symbol type.
+
+### 3. Missing Type Safety for Register Aliases
+
+Register aliases (`Symbol.Type.ALIAS`) are accepted in both REGISTER and LOCATION_REGISTER argument positions by InstructionAnalysisHandler. This means `.REG %POS %LR0` followed by `SETI %POS 42` compiles without error — but crashes at runtime because SETI writes to a location register via writeOperand, which rejects location bank IDs.
+
+Parameters already have this type safety (VARIABLE → REGISTER only, LOCATION_VARIABLE → LOCATION_REGISTER only, added in Phase G of the Register Bank Extension). Aliases should have the same. The same type safety gap exists in CallAnalysisHandler: identifier arguments in REF/VAL/LREF/LVAL positions are accepted without symbol type validation.
+
+### 4. Duplicate Scope Mechanism for Parameters
 
 Procedure parameters are resolved in Phase 7 (IrGenContext) via a separate scope stack (`procParamScopes`, `procLocationParamScopes`) that duplicates the SymbolTable's scope management. This violates the Single Source of Truth principle. The SymbolTable already has correct proc-scopes from Phase 4 (ProcedureSymbolCollector), and Phase 6 (AstPostProcessor) already uses ScopeTracker for scope-aware alias resolution. Parameters should use the same mechanism.
 
@@ -16,50 +30,157 @@ After cleanup:
 - Register aliases: resolved in Phase 6 via SymbolTable + IRegisterAlias → RegisterNode (unchanged)
 - Parameters: resolved in Phase 6 via SymbolTable + IParameterBinding → RegisterNode (same mechanism)
 
-### 2. Missing Type Safety for Register Aliases
-
-Register aliases (`Symbol.Type.ALIAS`) are accepted in both REGISTER and LOCATION_REGISTER argument positions by InstructionAnalysisHandler. This means `.REG %POS %LR0` followed by `SETI %POS 42` compiles without error — but crashes at runtime because SETI writes to a location register via writeOperand, which rejects location bank IDs.
-
-Parameters already have this type safety (VARIABLE → REGISTER only, LOCATION_VARIABLE → LOCATION_REGISTER only, added in Phase G of the Register Bank Extension). Aliases should have the same.
-
-### 3. Misleading Symbol Type Names
-
-`Symbol.Type.VARIABLE` and `LOCATION_VARIABLE` are used exclusively for procedure parameters. "Variable" implies a named storage location (like `int x`); "parameter" is what they actually are.
-
 ## Solution
 
-### Step 1: Alias Type Safety
+Four implementation steps, each self-contained, compilable, and testable.
 
-Split `Symbol.Type.ALIAS` into data and location variants.
+### Dependencies
+
+```
+Step 1 (Parameter Rename) ─┬─→ Step 3 (Call Validation) ─→ Step 4 (Parameter Resolution)
+Step 2 (Alias Type Split) ─┘
+```
+
+Steps 1 and 2 are independent of each other. Step 3 requires both. Step 4 requires Step 1 and is cleaner after Step 3.
+
+### Target Symbol Type Enum
+
+After all steps, `Symbol.Type` contains:
+
+```java
+LABEL,                     // Label definition
+CONSTANT,                  // Named constant (.DEFINE)
+PROCEDURE,                 // Procedure definition (.PROC)
+MODULE_ALIAS,              // .IMPORT/.REQUIRE AS (module alias, not a register)
+REGISTER_ALIAS_DATA,       // .REG %X %DR0 (target is data bank: DR, PDR, SDR)
+REGISTER_ALIAS_LOCATION,   // .REG %X %LR0 (target is location bank: LR, PLR, SLR)
+PARAMETER_DATA,            // REF/VAL procedure parameter (→ FDR)
+PARAMETER_LOCATION         // LREF/LVAL procedure parameter (→ FLR)
+```
+
+---
+
+### Step 1: Parameter Rename
+
+Pure mechanical rename. No behavioral change. All existing tests remain green.
 
 **Symbol.java** (`model/symbols/`):
-- `ALIAS` — data register alias (target is DR, PDR, SDR, or FDR bank)
-- New: `LOCATION_ALIAS` — location register alias (target is LR, PLR, SLR, or FLR bank)
+- Rename `VARIABLE` → `PARAMETER_DATA`
+- Rename `LOCATION_VARIABLE` → `PARAMETER_LOCATION`
+- `VARIABLE` and `LOCATION_VARIABLE` are deleted — no remaining usage.
 
-**RegAnalysisHandler.java** (`features/reg/`):
-- Determine alias type from target register bank: `RegisterBank.forId(resolvedId).isLocation` → LOCATION_ALIAS, else → ALIAS
-- Currently uses 4-arg Symbol constructor with RegNode — no change to constructor, just the Symbol.Type
+**ProcedureSymbolCollector.java** (`features/proc/`):
+- `Symbol.Type.VARIABLE` → `Symbol.Type.PARAMETER_DATA` (lines 30, 35)
+- `Symbol.Type.LOCATION_VARIABLE` → `Symbol.Type.PARAMETER_LOCATION` (lines 40, 45)
 
 **InstructionAnalysisHandler.java** (`features/instruction/`):
-- ALIAS → accepted only in REGISTER position (was: REGISTER or LOCATION_REGISTER)
-- LOCATION_ALIAS → accepted only in LOCATION_REGISTER position (new case branch)
-- Compile-time error: data alias in location instruction, location alias in data instruction
+- `Symbol.Type.VARIABLE` → `Symbol.Type.PARAMETER_DATA` (line 103)
+- `Symbol.Type.LOCATION_VARIABLE` → `Symbol.Type.PARAMETER_LOCATION` (line 113)
+- Logic unchanged: PARAMETER_DATA → REGISTER only, PARAMETER_LOCATION → LOCATION_REGISTER only.
 
 **TokenKindMapper.java** (`frontend/tokenmap/`):
-- `ALIAS, LOCATION_ALIAS → TokenKind.ALIAS` (Visualizer does not distinguish)
+- `case VARIABLE, LOCATION_VARIABLE` → `case PARAMETER_DATA, PARAMETER_LOCATION`
+- Map target: `TokenKind.VARIABLE` → `TokenKind.PARAMETER`
 
-**CallAnalysisHandler.java** (`features/proc/`):
-- LREF/LVAL argument validation: if the argument resolves to an ALIAS symbol, reject it (data alias in location parameter position). Only accept LOCATION_ALIAS. Error: "LREF argument must be a location register, but '%MY_REG' is a data register alias."
-- REF/VAL argument validation: if the argument resolves to a LOCATION_ALIAS symbol, reject it (location alias in data parameter position). Only accept ALIAS. Error: "REF argument must be a data register, but '%POS' is a location register alias."
+**TokenKind.java** (`api/`):
+- Rename `VARIABLE` → `PARAMETER`
+- New: `REGISTER` — for physical register tokens (`%DR0`, `%LR1`) that are not aliases and not parameters. Previously misclassified as `VARIABLE`.
+
+**ProcedureTokenMapContributor.java** (`features/proc/`):
+- Line 40: `TokenKind.VARIABLE` → `TokenKind.PARAMETER`
+
+**TokenMapGenerator.java** (`frontend/tokenmap/`):
+- Line 222: `TokenKind.VARIABLE` → `TokenKind.REGISTER` — physical register tokens (`%DR0`, `%LR1` etc.) that are not aliases. Previously misclassified as VARIABLE.
+
+**Visualizer:**
+- `ParameterTokenHandler.js` line 26: `tokenInfo.tokenType === 'PARAMETER'` instead of `'VARIABLE'`
+- `RegisterTokenHandler.js` line 20: `type === 'ALIAS' || type === 'REGISTER'` instead of `type === 'ALIAS' || (type === 'VARIABLE' && token.startsWith('%'))`
 
 **Tests:**
-- Test: `.REG %POS %LR0` then `SETI %POS 42` → compile error (location alias in data instruction)
-- Test: `.REG %COUNTER %DR0` then `CRLR %COUNTER` → compile error (data alias in location instruction)
-- Test: `.REG %POS %LR0` then `SKLR %POS` → OK (location alias in location instruction)
+- All existing tests remain green (pure rename).
 
-### Step 2: Parameter Resolution via SymbolTable
+---
 
-Move parameter resolution from Phase 7 (IrGenContext) to Phase 6 (AstPostProcessor) using the existing ScopeTracker and SymbolTable infrastructure.
+### Step 2: Alias Type Split
+
+Split `Symbol.Type.ALIAS` into three distinct types. Introduces type safety for register aliases in instructions and separates module aliases.
+
+**Symbol.java** (`model/symbols/`):
+- Delete `ALIAS`
+- Add: `MODULE_ALIAS`, `REGISTER_ALIAS_DATA`, `REGISTER_ALIAS_LOCATION`
+
+**RegAnalysisHandler.java** (`features/reg/`):
+- Determine alias type from target register bank during the existing validation loop in `processRegDirective`: if the matched `RegisterBank.isLocation` → `REGISTER_ALIAS_LOCATION`, else → `REGISTER_ALIAS_DATA`
+- Currently uses 4-arg Symbol constructor with RegNode — no change to constructor, just the Symbol.Type
+
+**ImportSymbolCollector.java** (`features/importdir/`):
+- `Symbol.Type.ALIAS` → `Symbol.Type.MODULE_ALIAS`
+
+**RequireSymbolCollector.java** (`features/require/`):
+- `Symbol.Type.ALIAS` → `Symbol.Type.MODULE_ALIAS`
+
+**InstructionAnalysisHandler.java** (`features/instruction/`):
+- Replace the single `ALIAS` branch (line 93) with three branches:
+  - `REGISTER_ALIAS_DATA` → accepted only in REGISTER position
+  - `REGISTER_ALIAS_LOCATION` → accepted only in LOCATION_REGISTER position
+  - `MODULE_ALIAS` → compile-time error: "Module alias '%s' cannot be used as an instruction argument."
+
+**AstPostProcessor.java** (`frontend/postprocess/`):
+- Replace `Symbol.Type.ALIAS` check (line 105) with both register alias types:
+
+```java
+if ((symbol.type() == Symbol.Type.REGISTER_ALIAS_DATA || symbol.type() == Symbol.Type.REGISTER_ALIAS_LOCATION)
+        && symbol.node() instanceof IRegisterAlias alias) {
+    createRegisterReplacement(idNode, identifierName.toUpperCase(), alias.register());
+    return;
+}
+```
+
+The `instanceof IRegisterAlias` guard is defense-in-depth — the type split already separates register aliases from module aliases, but the instanceof check prevents regressions.
+
+**TokenKindMapper.java** (`frontend/tokenmap/`):
+- Replace `case ALIAS → TokenKind.ALIAS` with:
+  - `case REGISTER_ALIAS_DATA, REGISTER_ALIAS_LOCATION → TokenKind.ALIAS`
+  - `case MODULE_ALIAS → TokenKind.MODULE_ALIAS`
+
+**TokenKind.java** (`api/`):
+- New: `MODULE_ALIAS` — for module alias tokens (.IMPORT/.REQUIRE AS names). Enables future visualizer annotation of module aliases.
+
+**Tests:**
+- `.REG %POS %LR0` + `SETI %POS 42` → compile error (location register alias in data instruction)
+- `.REG %COUNTER %DR0` + `CRLR %COUNTER` → compile error (data register alias in location instruction)
+- `.REG %POS %LR0` + `SKLR %POS` → OK (location register alias in location instruction)
+- `.REG %COUNTER %DR0` + `SETI %COUNTER 42` → OK (data register alias in data instruction)
+- Module alias as instruction argument → compile error
+- Existing alias tests remain green
+
+---
+
+### Step 3: CallAnalysisHandler Type Safety
+
+Add symbol type validation for identifier arguments in CALL instructions. Requires Step 1 and Step 2 (all new Symbol types must exist).
+
+**CallAnalysisHandler.java** (`features/proc/`):
+- Add symbol resolution for IdentifierNode arguments in REF, VAL, LREF, LVAL validation loops. For each IdentifierNode argument, call `symbolTable.resolve()` and check the symbol type:
+  - REF/VAL arguments: accept `REGISTER_ALIAS_DATA` and `PARAMETER_DATA`. Reject `REGISTER_ALIAS_LOCATION` (error: "REF argument '%s' is a location register alias, expected a data register."). Reject `PARAMETER_LOCATION` (error: "REF argument '%s' is a location parameter, expected a data register."). Reject `MODULE_ALIAS` (error: "Module alias '%s' cannot be used as a CALL argument.").
+  - LREF/LVAL arguments: accept `REGISTER_ALIAS_LOCATION` and `PARAMETER_LOCATION`. Reject `REGISTER_ALIAS_DATA` (error: "LREF argument '%s' is a data register alias, expected a location register."). Reject `PARAMETER_DATA` (error: "LREF argument '%s' is a data parameter, expected a location register."). Reject `MODULE_ALIAS` (error: "Module alias '%s' cannot be used as a CALL argument.").
+  - Unresolved identifiers in REF/LREF positions → error (must resolve to a register). Unresolved identifiers in VAL/LVAL positions → allow (may be forward-referenced labels).
+
+**Tests:**
+- `.REG %MY_REG %DR0` + `CALL proc LREF %MY_REG` → compile error (data register alias as LREF argument)
+- `.REG %MY_LOC %LR0` + `CALL proc REF %MY_LOC` → compile error (location register alias as REF argument)
+- `.REG %MY_LOC %LR0` + `CALL proc LREF %MY_LOC` → OK (location register alias as LREF argument)
+- `.REG %MY_REG %DR0` + `CALL proc REF %MY_REG` → OK (data register alias as REF argument)
+- Data parameter as LREF argument → compile error
+- Location parameter as REF argument → compile error
+- Module alias as CALL REF argument → compile error
+- Module alias as CALL LREF argument → compile error
+
+---
+
+### Step 4: Parameter Resolution via SymbolTable
+
+Move parameter resolution from Phase 7 (IrGenContext) to Phase 6 (AstPostProcessor) using the existing ScopeTracker and SymbolTable infrastructure. Requires Step 1. Cleaner after Step 3 (CallAnalysisHandler already validates before resolution changes).
 
 **New files:**
 
@@ -88,25 +209,17 @@ public record ParameterBinding(String targetRegister) implements AstNode, IParam
 }
 ```
 
-**Symbol.java** (`model/symbols/`):
-- Rename `VARIABLE` → `PARAMETER` (VARIABLE is deleted — no remaining usage)
-- Rename `LOCATION_VARIABLE` → `LOCATION_PARAMETER` (LOCATION_VARIABLE is deleted — no remaining usage)
-
-**TokenKind.java** (`api/`):
-- Rename `VARIABLE` → `PARAMETER`
-- New: `REGISTER` — for physical register tokens (`%DR0`, `%LR1`) that are not aliases and not parameters. Previously these were misclassified as `VARIABLE`.
-
 **ProcedureSymbolCollector.java** (`features/proc/`):
-- REF/VAL parameters: `Symbol.Type.PARAMETER` with `new ParameterBinding("%FDR" + dataIndex)`
-- LREF/LVAL parameters: `Symbol.Type.LOCATION_PARAMETER` with `new ParameterBinding("%FLR" + locationIndex)`
+- REF/VAL parameters: `Symbol.Type.PARAMETER_DATA` with `new ParameterBinding("%FDR" + dataIndex)`
+- LREF/LVAL parameters: `Symbol.Type.PARAMETER_LOCATION` with `new ParameterBinding("%FLR" + locationIndex)`
 - dataIndex increments across REF + VAL (all map to FDR)
 - locationIndex increments across LREF + LVAL (all map to FLR)
 
 **AstPostProcessor.java** (`frontend/postprocess/`):
-- In `collectReplacements()`, after existing ALIAS resolution, add PARAMETER/LOCATION_PARAMETER resolution:
+- In `collectReplacements()`, after existing register alias resolution, add parameter resolution:
 
 ```java
-if ((symbol.type() == Symbol.Type.PARAMETER || symbol.type() == Symbol.Type.LOCATION_PARAMETER)
+if ((symbol.type() == Symbol.Type.PARAMETER_DATA || symbol.type() == Symbol.Type.PARAMETER_LOCATION)
         && symbol.node() instanceof IParameterBinding pb) {
     createRegisterReplacement(idNode, identifierName.toUpperCase(), pb.targetRegister());
     return;
@@ -124,7 +237,20 @@ This uses the existing ScopeTracker — when inside a proc, symbolTable.resolve(
 - Method `popProcedureLocationParams()`
 - Method `resolveProcedureParam(String)`
 
-In `convertOperand()`: remove the `resolveProcedureParam` call. Parameter identifiers are already replaced by RegisterNodes in Phase 6. Phase 7 never sees them. The `convertOperand` method only handles RegisterNode, NumberLiteralNode, TypedLiteralNode, VectorLiteralNode, and IdentifierNode (for constants and labels). No parameter-specific code needed.
+In `convertOperand()`: delete the `resolveProcedureParam` call and its surrounding if-block (lines 225-228). The IdentifierNode branch becomes:
+
+```java
+} else if (node instanceof IdentifierNode id) {
+    String nameU = id.text().toUpperCase();
+    Optional<IrOperand> constOpt = resolveConstant(nameU);
+    if (constOpt.isPresent()) {
+        return constOpt.get();
+    }
+    return new IrLabelRef(id.text());
+}
+```
+
+After Phase 6, the only IdentifierNodes reaching Phase 7 are constants (resolved here via `resolveConstant`) and label/procedure references (emitted as `IrLabelRef`, linked in Phase 10). All register aliases and parameters have been replaced by RegisterNodes in Phase 6 and take the `RegisterNode` branch (line 214). The `IrLabelRef` fallthrough is correct — an IdentifierNode that is neither constant nor label would be a compiler bug, caught as an undefined-label error in Phase 10 linking.
 
 **ProcedureNodeConverter.java** (`features/proc/`) — DELETE:
 - `allDataParams` list building
@@ -137,72 +263,41 @@ In `convertOperand()`: remove the `resolveProcedureParam` call. Parameter identi
 What remains: emit proc_enter/proc_exit directives (with lrefArity/lvalArity for marshalling) and convert body via `ctx.convert()`.
 
 **CallNodeConverter.java** (`features/proc/`):
-- Remove `resolveProcedureParam` call. Parameter identifiers are already resolved to RegisterNodes by Phase 6.
-
-**InstructionAnalysisHandler.java** (`features/instruction/`):
-- Rename VARIABLE → PARAMETER, LOCATION_VARIABLE → LOCATION_PARAMETER
-- PARAMETER → accepted only in REGISTER position (unchanged logic, new name)
-- LOCATION_PARAMETER → accepted only in LOCATION_REGISTER position (unchanged logic, new name)
-
-**CallAnalysisHandler.java** (`features/proc/`):
-- No Symbol.Type references remaining (legacy WITH validation was removed). No changes needed for the rename.
-
-**TokenKindMapper.java** (`frontend/tokenmap/`):
-- `PARAMETER, LOCATION_PARAMETER → TokenKind.PARAMETER`
-
-**ProcedureTokenMapContributor.java** (`features/proc/`):
-- Line 41: `TokenKind.VARIABLE` → `TokenKind.PARAMETER` (parameter tokens in the TokenMap)
-
-**TokenMapGenerator.java** (`frontend/tokenmap/`):
-- Line 222: `TokenKind.VARIABLE` → `TokenKind.REGISTER` — physical register tokens (`%DR0`, `%LR1` etc.) that are not aliases. Previously misclassified as VARIABLE.
-
-**Visualizer:**
-- `ParameterTokenHandler.js`: `tokenInfo.tokenType === 'PARAMETER'` instead of `'VARIABLE'`
-- `RegisterTokenHandler.js`: `type === 'REGISTER'` instead of `type === 'VARIABLE' && token.startsWith('%')`
+- No changes needed. `ctx.convertOperand()` already handles RegisterNode (which parameters become after Phase 6 resolution) and IdentifierNode (for labels). The `resolveProcedureParam` call is inside `convertOperand` (deleted in IrGenContext above), not in CallNodeConverter.
 
 **Compiler.java:**
 - No changes needed. Phase 6 AstPostProcessor already has ScopeTracker. Phase 7 IrGenerator doesn't need new dependencies.
 
-### Verification
-
-After both steps:
-
-1. **Single Source of Truth**: SymbolTable is the sole authority for all symbol resolution (aliases, parameters, constants, labels). IrGenContext has no scope management.
-2. **Phase consistency**: All symbolic register references (aliases AND parameters) resolved in Phase 6. Phase 7 does only AST→IR conversion.
-3. **Type safety**: Data symbols (ALIAS, PARAMETER) accepted only in REGISTER positions. Location symbols (LOCATION_ALIAS, LOCATION_PARAMETER) accepted only in LOCATION_REGISTER positions. Compile-time errors for type mismatches.
-4. **Correct naming**: PARAMETER/LOCATION_PARAMETER instead of VARIABLE/LOCATION_VARIABLE.
-5. **No duplicate scope tracking**: IrGenContext's procParamScopes/procLocationParamScopes eliminated.
-
-### Complete Symbol Type Table
-
-| Symbol.Type | Purpose | InstructionAnalysisHandler | TokenKind | Resolution Phase |
-|---|---|---|---|---|
-| ALIAS | Data register alias (.REG %X %DR0) | REGISTER only | ALIAS | Phase 6 (IRegisterAlias) |
-| LOCATION_ALIAS | Location register alias (.REG %X %LR0) | LOCATION_REGISTER only | ALIAS | Phase 6 (IRegisterAlias) |
-| PARAMETER | Data proc parameter (REF/VAL) | REGISTER only | PARAMETER | Phase 6 (IParameterBinding) |
-| LOCATION_PARAMETER | Location proc parameter (LREF/LVAL) | LOCATION_REGISTER only | PARAMETER | Phase 6 (IParameterBinding) |
-| CONSTANT | Named constant (.DEFINE) | LITERAL | CONSTANT | Phase 6 (flat map) |
-| LABEL | Label definition | LABEL, VECTOR | LABEL | Phase 10 (Linking) |
-| PROCEDURE | Procedure definition (.PROC) | LABEL | PROCEDURE | Phase 10 (Linking) |
-| — (no Symbol) | Physical register (%DR0, %LR1) | — (RegisterNode) | REGISTER | Not resolved (already concrete) |
-
-### Tests
-
-**Step 1 tests (alias type safety):**
-- `.REG %POS %LR0` + `SETI %POS 42` → compile error (location alias in data instruction)
-- `.REG %COUNTER %DR0` + `CRLR %COUNTER` → compile error (data alias in location instruction)
-- `.REG %POS %LR0` + `SKLR %POS` → OK (location alias in location instruction)
-- `.REG %COUNTER %DR0` + `SETI %COUNTER 42` → OK (data alias in data instruction)
-- `.REG %MY_REG %DR0` + `CALL proc LREF %MY_REG` → compile error (data alias as LREF argument)
-- `.REG %MY_LOC %LR0` + `CALL proc REF %MY_LOC` → compile error (location alias as REF argument)
-- `.REG %MY_LOC %LR0` + `CALL proc LREF %MY_LOC` → OK (location alias as LREF argument)
-- `.REG %MY_REG %DR0` + `CALL proc REF %MY_REG` → OK (data alias as REF argument)
-- Existing alias tests remain green
-
-**Step 2 tests (parameter resolution):**
+**Tests:**
 - Existing parameter scoping tests (RegisterAliasScopeTest) adapted to new Symbol types
 - Parameters inside proc resolve to correct FDR/FLR RegisterNodes after Phase 6
 - Parameters outside proc scope are not visible
 - Shadowing: proc-level parameter shadows module-level alias
 - IrGenContext has no procParamScopes/procLocationParamScopes fields (verified via grep)
 - All existing integration tests and CLI smoke tests green
+
+---
+
+## Verification
+
+After all steps:
+
+1. **Single Source of Truth**: SymbolTable is the sole authority for all symbol resolution (aliases, parameters, constants, labels). IrGenContext has no scope management.
+2. **Phase consistency**: All symbolic register references (aliases AND parameters) resolved in Phase 6. Phase 7 does only AST→IR conversion.
+3. **Type safety**: Data symbols (REGISTER_ALIAS_DATA, PARAMETER_DATA) accepted only in REGISTER positions. Location symbols (REGISTER_ALIAS_LOCATION, PARAMETER_LOCATION) accepted only in LOCATION_REGISTER positions. Module aliases (MODULE_ALIAS) rejected in all instruction and CALL argument positions. Compile-time errors for type mismatches.
+4. **Correct naming**: Explicit Symbol types — no ambiguous "VARIABLE" or overloaded "ALIAS".
+5. **No duplicate scope tracking**: IrGenContext's procParamScopes/procLocationParamScopes eliminated.
+
+## Complete Symbol Type Table
+
+| Symbol.Type | Purpose | InstructionAnalysisHandler | CallAnalysisHandler | TokenKind | Resolution Phase |
+|---|---|---|---|---|---|
+| REGISTER_ALIAS_DATA | Data register alias (.REG %X %DR0) | REGISTER only | REF/VAL only | ALIAS | Phase 6 (IRegisterAlias) |
+| REGISTER_ALIAS_LOCATION | Location register alias (.REG %X %LR0) | LOCATION_REGISTER only | LREF/LVAL only | ALIAS | Phase 6 (IRegisterAlias) |
+| MODULE_ALIAS | Module alias (.IMPORT/.REQUIRE AS) | Rejected (error) | Rejected (error) | MODULE_ALIAS | Not resolved (namespace prefix) |
+| PARAMETER_DATA | Data proc parameter (REF/VAL) | REGISTER only | REF/VAL only | PARAMETER | Phase 6 (IParameterBinding) |
+| PARAMETER_LOCATION | Location proc parameter (LREF/LVAL) | LOCATION_REGISTER only | LREF/LVAL only | PARAMETER | Phase 6 (IParameterBinding) |
+| CONSTANT | Named constant (.DEFINE) | LITERAL | — | CONSTANT | Phase 6 (flat map) |
+| LABEL | Label definition | LABEL, VECTOR | — | LABEL | Phase 10 (Linking) |
+| PROCEDURE | Procedure definition (.PROC) | LABEL | procedure target | PROCEDURE | Phase 10 (Linking) |
+| — (no Symbol) | Physical register (%DR0, %LR1) | — (RegisterNode) | — (RegisterNode) | REGISTER | Not resolved (already concrete) |

--- a/src/main/java/org/evochora/compiler/api/TokenKind.java
+++ b/src/main/java/org/evochora/compiler/api/TokenKind.java
@@ -11,8 +11,10 @@ public enum TokenKind {
     CONSTANT,
     /** A procedure defined with .PROC. */
     PROCEDURE,
-    /** A variable, such as a procedure parameter. */
-    VARIABLE,
+    /** A procedure parameter (REF/VAL/LREF/LVAL). */
+    PARAMETER,
+    /** A physical register token (%DR0, %LR1) that is not an alias or parameter. */
+    REGISTER,
     /** A register alias defined with .REG. */
     ALIAS,
     /** An instruction opcode (e.g., CALL, RET, NOP, MOV). */

--- a/src/main/java/org/evochora/compiler/api/TokenKind.java
+++ b/src/main/java/org/evochora/compiler/api/TokenKind.java
@@ -17,6 +17,8 @@ public enum TokenKind {
     REGISTER,
     /** A register alias defined with .REG. */
     ALIAS,
+    /** A module alias defined with .IMPORT AS or .REQUIRE AS. */
+    MODULE_ALIAS,
     /** An instruction opcode (e.g., CALL, RET, NOP, MOV). */
     INSTRUCTION
 }

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportSymbolCollector.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportSymbolCollector.java
@@ -20,6 +20,6 @@ public class ImportSymbolCollector implements ISymbolCollector {
     @Override
     public void collect(AstNode node, SymbolTable symbolTable, DiagnosticsEngine diagnostics) {
         ImportNode importNode = (ImportNode) node;
-        symbolTable.define(new Symbol(importNode.alias(), importNode.sourceInfo(), Symbol.Type.ALIAS, importNode));
+        symbolTable.define(new Symbol(importNode.alias(), importNode.sourceInfo(), Symbol.Type.MODULE_ALIAS, importNode));
     }
 }

--- a/src/main/java/org/evochora/compiler/features/instruction/InstructionAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/instruction/InstructionAnalysisHandler.java
@@ -100,7 +100,7 @@ public class InstructionAnalysisHandler implements IAnalysisHandler {
                                         instructionNode.sourceInfo().lineNumber()
                                 );
                             }
-                        } else if (symbol.type() == Symbol.Type.VARIABLE) {
+                        } else if (symbol.type() == Symbol.Type.PARAMETER_DATA) {
                             // Accept data parameters (REF/VAL → FDR) in REGISTER positions
                             if (expectedType != InstructionArgumentType.REGISTER) {
                                 diagnostics.reportError(
@@ -110,7 +110,7 @@ public class InstructionAnalysisHandler implements IAnalysisHandler {
                                         instructionNode.sourceInfo().lineNumber()
                                 );
                             }
-                        } else if (symbol.type() == Symbol.Type.LOCATION_VARIABLE) {
+                        } else if (symbol.type() == Symbol.Type.PARAMETER_LOCATION) {
                             // Accept location parameters (LREF/LVAL → FLR) in LOCATION_REGISTER positions
                             if (expectedType != InstructionArgumentType.LOCATION_REGISTER) {
                                 diagnostics.reportError(

--- a/src/main/java/org/evochora/compiler/features/instruction/InstructionAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/instruction/InstructionAnalysisHandler.java
@@ -90,16 +90,31 @@ public class InstructionAnalysisHandler implements IAnalysisHandler {
                                         instructionNode.sourceInfo().lineNumber()
                                 );
                             }
-                        } else if (symbol.type() == Symbol.Type.ALIAS) {
-                            // Register aliases are valid for REGISTER and LOCATION_REGISTER arguments (will be resolved later)
-                            if (expectedType != InstructionArgumentType.REGISTER && expectedType != InstructionArgumentType.LOCATION_REGISTER) {
+                        } else if (symbol.type() == Symbol.Type.REGISTER_ALIAS_DATA) {
+                            if (expectedType != InstructionArgumentType.REGISTER) {
                                 diagnostics.reportError(
-                                        String.format("Argument %d for instruction '%s' has the wrong type. Expected %s, but got ALIAS.",
+                                        String.format("Argument %d for instruction '%s' has the wrong type. Expected %s, but got data register alias.",
                                                 i + 1, instructionName, expectedType),
                                         instructionNode.sourceInfo().fileName(),
                                         instructionNode.sourceInfo().lineNumber()
                                 );
                             }
+                        } else if (symbol.type() == Symbol.Type.REGISTER_ALIAS_LOCATION) {
+                            if (expectedType != InstructionArgumentType.LOCATION_REGISTER) {
+                                diagnostics.reportError(
+                                        String.format("Argument %d for instruction '%s' has the wrong type. Expected %s, but got location register alias.",
+                                                i + 1, instructionName, expectedType),
+                                        instructionNode.sourceInfo().fileName(),
+                                        instructionNode.sourceInfo().lineNumber()
+                                );
+                            }
+                        } else if (symbol.type() == Symbol.Type.MODULE_ALIAS) {
+                            diagnostics.reportError(
+                                    String.format("Module alias '%s' cannot be used as an instruction argument.",
+                                            idNode.text()),
+                                    instructionNode.sourceInfo().fileName(),
+                                    instructionNode.sourceInfo().lineNumber()
+                            );
                         } else if (symbol.type() == Symbol.Type.PARAMETER_DATA) {
                             // Accept data parameters (REF/VAL → FDR) in REGISTER positions
                             if (expectedType != InstructionArgumentType.REGISTER) {

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -69,7 +69,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         // Validate REF argument types
         for (AstNode refArg : callNode.refArguments()) {
             if (refArg instanceof RegisterNode) continue;
-            if (refArg instanceof IdentifierNode) continue;
+            if (refArg instanceof IdentifierNode idNode) {
+                validateDataIdentifier(idNode, "REF", symbolTable, diagnostics, callNode);
+                continue;
+            }
             diagnostics.reportError("REF arguments must be registers.",
                     callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
         }
@@ -79,7 +82,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
             if (valArg instanceof RegisterNode) continue;
             if (valArg instanceof NumberLiteralNode) continue;
             if (valArg instanceof TypedLiteralNode) continue;
-            if (valArg instanceof IdentifierNode) continue;
+            if (valArg instanceof IdentifierNode idNode) {
+                validateDataIdentifierOrLabel(idNode, "VAL", symbolTable, diagnostics, callNode);
+                continue;
+            }
             diagnostics.reportError("VAL arguments must be registers, literals, or labels.",
                     callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
         }
@@ -106,8 +112,8 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                 }
                 diagnostics.reportError("LREF arguments must be location registers (LR, PLR, SLR), got '" + regNode.getName() + "'.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
-            } else if (lrefArg instanceof IdentifierNode) {
-                continue; // Alias — resolved later
+            } else if (lrefArg instanceof IdentifierNode idNode) {
+                validateLocationIdentifier(idNode, "LREF", symbolTable, diagnostics, callNode);
             } else {
                 diagnostics.reportError("LREF arguments must be location registers.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
@@ -124,12 +130,94 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                 }
                 diagnostics.reportError("LVAL arguments must be location registers, got '" + regNode.getName() + "'.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
-            } else if (lvalArg instanceof IdentifierNode) {
-                continue; // Alias or label — resolved later in IrGenContext.convertOperand()
+            } else if (lvalArg instanceof IdentifierNode idNode) {
+                validateLocationIdentifierOrLabel(idNode, "LVAL", symbolTable, diagnostics, callNode);
             } else {
                 diagnostics.reportError("LVAL arguments must be location registers.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
             }
+        }
+    }
+
+    private void validateDataIdentifier(IdentifierNode idNode, String position,
+                                        SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+        Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
+        if (opt.isEmpty()) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+            return;
+        }
+        Symbol.Type type = opt.get().symbol().type();
+        if (type == Symbol.Type.REGISTER_ALIAS_DATA || type == Symbol.Type.PARAMETER_DATA) return;
+        if (type == Symbol.Type.REGISTER_ALIAS_LOCATION) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a location register alias, expected a data register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.PARAMETER_LOCATION) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a location parameter, expected a data register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.MODULE_ALIAS) {
+            diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        }
+    }
+
+    private void validateDataIdentifierOrLabel(IdentifierNode idNode, String position,
+                                               SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+        Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
+        if (opt.isEmpty()) return;
+        Symbol.Type type = opt.get().symbol().type();
+        if (type == Symbol.Type.REGISTER_ALIAS_DATA || type == Symbol.Type.PARAMETER_DATA) return;
+        if (type == Symbol.Type.LABEL || type == Symbol.Type.PROCEDURE || type == Symbol.Type.CONSTANT) return;
+        if (type == Symbol.Type.REGISTER_ALIAS_LOCATION) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a location register alias, expected a data register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.PARAMETER_LOCATION) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a location parameter, expected a data register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.MODULE_ALIAS) {
+            diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        }
+    }
+
+    private void validateLocationIdentifier(IdentifierNode idNode, String position,
+                                            SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+        Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
+        if (opt.isEmpty()) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+            return;
+        }
+        Symbol.Type type = opt.get().symbol().type();
+        if (type == Symbol.Type.REGISTER_ALIAS_LOCATION || type == Symbol.Type.PARAMETER_LOCATION) return;
+        if (type == Symbol.Type.REGISTER_ALIAS_DATA) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a data register alias, expected a location register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.PARAMETER_DATA) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a data parameter, expected a location register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.MODULE_ALIAS) {
+            diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        }
+    }
+
+    private void validateLocationIdentifierOrLabel(IdentifierNode idNode, String position,
+                                                   SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+        Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
+        if (opt.isEmpty()) return;
+        Symbol.Type type = opt.get().symbol().type();
+        if (type == Symbol.Type.REGISTER_ALIAS_LOCATION || type == Symbol.Type.PARAMETER_LOCATION) return;
+        if (type == Symbol.Type.LABEL || type == Symbol.Type.PROCEDURE || type == Symbol.Type.CONSTANT) return;
+        if (type == Symbol.Type.REGISTER_ALIAS_DATA) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a data register alias, expected a location register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.PARAMETER_DATA) {
+            diag.reportError(position + " argument '" + idNode.text() + "' is a data parameter, expected a location register.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else if (type == Symbol.Type.MODULE_ALIAS) {
+            diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         }
     }
 }

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -70,7 +70,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         for (AstNode refArg : callNode.refArguments()) {
             if (refArg instanceof RegisterNode) continue;
             if (refArg instanceof IdentifierNode idNode) {
-                validateDataIdentifier(idNode, "REF", symbolTable, diagnostics, callNode);
+                validateDataIdentifier(idNode, "REF", symbolTable, diagnostics);
                 continue;
             }
             diagnostics.reportError("REF arguments must be registers.",
@@ -83,7 +83,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
             if (valArg instanceof NumberLiteralNode) continue;
             if (valArg instanceof TypedLiteralNode) continue;
             if (valArg instanceof IdentifierNode idNode) {
-                validateDataIdentifierOrLabel(idNode, "VAL", symbolTable, diagnostics, callNode);
+                validateDataIdentifierOrLabel(idNode, "VAL", symbolTable, diagnostics);
                 continue;
             }
             diagnostics.reportError("VAL arguments must be registers, literals, or labels.",
@@ -113,7 +113,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                 diagnostics.reportError("LREF arguments must be location registers (LR, PLR, SLR), got '" + regNode.getName() + "'.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
             } else if (lrefArg instanceof IdentifierNode idNode) {
-                validateLocationIdentifier(idNode, "LREF", symbolTable, diagnostics, callNode);
+                validateLocationIdentifier(idNode, "LREF", symbolTable, diagnostics);
             } else {
                 diagnostics.reportError("LREF arguments must be location registers.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
@@ -131,7 +131,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                 diagnostics.reportError("LVAL arguments must be location registers, got '" + regNode.getName() + "'.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
             } else if (lvalArg instanceof IdentifierNode idNode) {
-                validateLocationIdentifierOrLabel(idNode, "LVAL", symbolTable, diagnostics, callNode);
+                validateLocationIdentifierOrLabel(idNode, "LVAL", symbolTable, diagnostics);
             } else {
                 diagnostics.reportError("LVAL arguments must be location registers.",
                         callNode.sourceInfo().fileName(), callNode.sourceInfo().lineNumber());
@@ -140,7 +140,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
     }
 
     private void validateDataIdentifier(IdentifierNode idNode, String position,
-                                        SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+                                        SymbolTable st, DiagnosticsEngine diag) {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) {
             diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
@@ -166,7 +166,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
     }
 
     private void validateDataIdentifierOrLabel(IdentifierNode idNode, String position,
-                                               SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+                                               SymbolTable st, DiagnosticsEngine diag) {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) return;
         Symbol.Type type = opt.get().symbol().type();
@@ -189,7 +189,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
     }
 
     private void validateLocationIdentifier(IdentifierNode idNode, String position,
-                                            SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+                                            SymbolTable st, DiagnosticsEngine diag) {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) {
             diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
@@ -215,7 +215,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
     }
 
     private void validateLocationIdentifierOrLabel(IdentifierNode idNode, String position,
-                                                   SymbolTable st, DiagnosticsEngine diag, CallNode call) {
+                                                   SymbolTable st, DiagnosticsEngine diag) {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) return;
         Symbol.Type type = opt.get().symbol().type();

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -144,24 +144,24 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) {
             diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
             return;
         }
         Symbol.Type type = opt.get().symbol().type();
         if (type == Symbol.Type.REGISTER_ALIAS_DATA || type == Symbol.Type.PARAMETER_DATA) return;
         if (type == Symbol.Type.REGISTER_ALIAS_LOCATION) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a location register alias, expected a data register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.PARAMETER_LOCATION) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a location parameter, expected a data register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
                     + "' must resolve to a data register alias or data parameter.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }
 
@@ -174,17 +174,17 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         if (type == Symbol.Type.LABEL || type == Symbol.Type.PROCEDURE || type == Symbol.Type.CONSTANT) return;
         if (type == Symbol.Type.REGISTER_ALIAS_LOCATION) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a location register alias, expected a data register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.PARAMETER_LOCATION) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a location parameter, expected a data register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
                     + "' must resolve to a data register, label, or constant.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }
 
@@ -193,24 +193,24 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         Optional<ResolvedSymbol> opt = st.resolve(idNode.text(), idNode.sourceInfo().fileName());
         if (opt.isEmpty()) {
             diag.reportError(position + " argument '" + idNode.text() + "' is not defined.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
             return;
         }
         Symbol.Type type = opt.get().symbol().type();
         if (type == Symbol.Type.REGISTER_ALIAS_LOCATION || type == Symbol.Type.PARAMETER_LOCATION) return;
         if (type == Symbol.Type.REGISTER_ALIAS_DATA) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a data register alias, expected a location register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.PARAMETER_DATA) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a data parameter, expected a location register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
                     + "' must resolve to a location register alias or location parameter.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }
 
@@ -223,17 +223,17 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         if (type == Symbol.Type.LABEL || type == Symbol.Type.PROCEDURE || type == Symbol.Type.CONSTANT) return;
         if (type == Symbol.Type.REGISTER_ALIAS_DATA) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a data register alias, expected a location register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.PARAMETER_DATA) {
             diag.reportError(position + " argument '" + idNode.text() + "' is a data parameter, expected a location register.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
                     + "' must resolve to a location register, label, or constant.",
-                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+                    idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }
 }

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -183,7 +183,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                     idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
-                    + "' must resolve to a data register, label, or constant.",
+                    + "' must resolve to a data register, label, constant, or procedure.",
                     idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }
@@ -232,7 +232,7 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                     idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         } else {
             diag.reportError(position + " argument '" + idNode.text()
-                    + "' must resolve to a location register, label, or constant.",
+                    + "' must resolve to a location register, label, constant, or procedure.",
                     idNode.sourceInfo().fileName(), idNode.sourceInfo().lineNumber());
         }
     }

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -158,6 +158,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else {
+            diag.reportError(position + " argument '" + idNode.text()
+                    + "' must resolve to a data register alias or data parameter.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         }
     }
 
@@ -198,6 +202,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else {
+            diag.reportError(position + " argument '" + idNode.text()
+                    + "' must resolve to a location register alias or location parameter.",
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         }
     }

--- a/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/proc/CallAnalysisHandler.java
@@ -181,6 +181,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else {
+            diag.reportError(position + " argument '" + idNode.text()
+                    + "' must resolve to a data register, label, or constant.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         }
     }
 
@@ -225,6 +229,10 @@ public class CallAnalysisHandler implements IAnalysisHandler {
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         } else if (type == Symbol.Type.MODULE_ALIAS) {
             diag.reportError("Module alias '" + idNode.text() + "' cannot be used as a CALL argument.",
+                    call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
+        } else {
+            diag.reportError(position + " argument '" + idNode.text()
+                    + "' must resolve to a location register, label, or constant.",
                     call.sourceInfo().fileName(), call.sourceInfo().lineNumber());
         }
     }

--- a/src/main/java/org/evochora/compiler/features/proc/ProcedureNodeConverter.java
+++ b/src/main/java/org/evochora/compiler/features/proc/ProcedureNodeConverter.java
@@ -6,16 +6,14 @@ import org.evochora.compiler.frontend.irgen.IrGenContext;
 import org.evochora.compiler.model.ir.IrDirective;
 import org.evochora.compiler.model.ir.IrValue;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * Converts {@link ProcedureNode} into generic enter/exit directives (namespace "core").
- * Registers both data parameters (REF/VAL → FDR) and location parameters (LREF/LVAL → FLR)
- * in separate IrGenContext scopes so that convertOperand resolves them to the correct register bank.
+ * Parameter identifiers are already resolved to RegisterNodes in Phase 6 by the
+ * AstPostProcessor via SymbolTable scope-aware lookup.
  */
 public final class ProcedureNodeConverter implements IAstNodeToIrConverter<ProcedureNode> {
 
@@ -23,26 +21,6 @@ public final class ProcedureNodeConverter implements IAstNodeToIrConverter<Proce
 	public void convert(ProcedureNode node, IrGenContext ctx) {
 		String qualifiedName = ctx.qualifyName(node.name());
 		ctx.emit(new org.evochora.compiler.model.ir.IrLabelDef(qualifiedName, ctx.sourceOf(node)));
-
-		// Data parameters (REF + VAL → FDR indices)
-		List<String> allDataParams = new ArrayList<>();
-		if (node.refParameters() != null) {
-			node.refParameters().stream().map(ProcedureNode.ParamDecl::name).forEach(allDataParams::add);
-		}
-		if (node.valParameters() != null) {
-			node.valParameters().stream().map(ProcedureNode.ParamDecl::name).forEach(allDataParams::add);
-		}
-		ctx.pushProcedureParams(allDataParams);
-
-		// Location parameters (LREF + LVAL → FLR indices)
-		List<String> allLocationParams = new ArrayList<>();
-		if (node.lrefParameters() != null) {
-			node.lrefParameters().stream().map(ProcedureNode.ParamDecl::name).forEach(allLocationParams::add);
-		}
-		if (node.lvalParameters() != null) {
-			node.lvalParameters().stream().map(ProcedureNode.ParamDecl::name).forEach(allLocationParams::add);
-		}
-		ctx.pushProcedureLocationParams(allLocationParams);
 
 		int lrefArity = node.lrefParameters() != null ? node.lrefParameters().size() : 0;
 		int lvalArity = node.lvalParameters() != null ? node.lvalParameters().size() : 0;
@@ -54,9 +32,6 @@ public final class ProcedureNodeConverter implements IAstNodeToIrConverter<Proce
 
 		Map<String, IrValue> exitArgs = buildProcArgs(node, qualifiedName, lrefArity, lvalArity);
 		ctx.emit(new IrDirective("core", "proc_exit", exitArgs, ctx.sourceOf(node)));
-
-		ctx.popProcedureLocationParams();
-		ctx.popProcedureParams();
 	}
 
 	private Map<String, IrValue> buildProcArgs(ProcedureNode node, String qualifiedName, int lrefArity, int lvalArity) {

--- a/src/main/java/org/evochora/compiler/features/proc/ProcedureSymbolCollector.java
+++ b/src/main/java/org/evochora/compiler/features/proc/ProcedureSymbolCollector.java
@@ -4,6 +4,7 @@ import org.evochora.compiler.diagnostics.DiagnosticsEngine;
 import org.evochora.compiler.frontend.semantics.analysis.ISymbolCollector;
 import org.evochora.compiler.model.ast.AstNode;
 
+import org.evochora.compiler.model.ast.ParameterBinding;
 import org.evochora.compiler.model.symbols.Symbol;
 import org.evochora.compiler.model.symbols.SymbolTable;
 
@@ -25,24 +26,30 @@ public class ProcedureSymbolCollector implements ISymbolCollector {
         SymbolTable.Scope newScope = symbolTable.enterScope(scopeName);
         symbolTable.registerNodeScope(node, newScope);
 
+        int dataIndex = 0;
         if (proc.refParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.refParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA,
+                        new ParameterBinding("%FDR" + dataIndex++)));
             }
         }
         if (proc.valParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.valParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA,
+                        new ParameterBinding("%FDR" + dataIndex++)));
             }
         }
+        int locationIndex = 0;
         if (proc.lrefParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.lrefParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION,
+                        new ParameterBinding("%FLR" + locationIndex++)));
             }
         }
         if (proc.lvalParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.lvalParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION,
+                        new ParameterBinding("%FLR" + locationIndex++)));
             }
         }
     }

--- a/src/main/java/org/evochora/compiler/features/proc/ProcedureSymbolCollector.java
+++ b/src/main/java/org/evochora/compiler/features/proc/ProcedureSymbolCollector.java
@@ -27,22 +27,22 @@ public class ProcedureSymbolCollector implements ISymbolCollector {
 
         if (proc.refParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.refParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.VARIABLE));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA));
             }
         }
         if (proc.valParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.valParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.VARIABLE));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_DATA));
             }
         }
         if (proc.lrefParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.lrefParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.LOCATION_VARIABLE));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION));
             }
         }
         if (proc.lvalParameters() != null) {
             for (ProcedureNode.ParamDecl p : proc.lvalParameters()) {
-                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.LOCATION_VARIABLE));
+                symbolTable.define(new Symbol(p.name(), p.sourceInfo(), Symbol.Type.PARAMETER_LOCATION));
             }
         }
     }

--- a/src/main/java/org/evochora/compiler/features/proc/ProcedureTokenMapContributor.java
+++ b/src/main/java/org/evochora/compiler/features/proc/ProcedureTokenMapContributor.java
@@ -12,7 +12,7 @@ import java.util.List;
  * Token map contributor for {@link ProcedureNode}.
  *
  * <p>Adds the procedure name as a {@link TokenKind#PROCEDURE} token in global scope,
- * and all formal parameters as {@link TokenKind#VARIABLE} tokens in the procedure's scope.</p>
+ * and all formal parameters as {@link TokenKind#PARAMETER} tokens in the procedure's scope.</p>
  */
 public class ProcedureTokenMapContributor implements ITokenMapContributor {
 
@@ -37,7 +37,7 @@ public class ProcedureTokenMapContributor implements ITokenMapContributor {
 		for (ProcedureNode.ParamDecl param : params) {
 			context.addToken(
 				param.sourceInfo(),
-				param.name(), TokenKind.VARIABLE, scope);
+				param.name(), TokenKind.PARAMETER, scope);
 		}
 	}
 }

--- a/src/main/java/org/evochora/compiler/features/reg/RegAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/reg/RegAnalysisHandler.java
@@ -22,12 +22,13 @@ public class RegAnalysisHandler implements IAnalysisHandler {
 
     private void processRegDirective(RegNode regNode, SymbolTable symbolTable, DiagnosticsEngine diagnostics) {
         String registerText = regNode.register();
-        if (!isValidRegister(registerText)) {
+        RegisterBank bank = resolveRegisterBank(registerText);
+        if (bank == null) {
             StringBuilder validRanges = new StringBuilder();
-            for (RegisterBank bank : RegisterBank.values()) {
-                if (bank.count > 0 && !bank.isForbidden) {
+            for (RegisterBank b : RegisterBank.values()) {
+                if (b.count > 0 && !b.isForbidden) {
                     if (!validRanges.isEmpty()) validRanges.append(", ");
-                    validRanges.append(bank.prefix).append("0-").append(bank.prefix).append(bank.count - 1);
+                    validRanges.append(b.prefix).append("0-").append(b.prefix).append(b.count - 1);
                 }
             }
             diagnostics.reportError(
@@ -38,31 +39,35 @@ public class RegAnalysisHandler implements IAnalysisHandler {
             return;
         }
 
-        symbolTable.define(new Symbol(regNode.alias(), regNode.sourceInfo(), Symbol.Type.ALIAS, regNode));
+        Symbol.Type aliasType = bank.isLocation ? Symbol.Type.REGISTER_ALIAS_LOCATION : Symbol.Type.REGISTER_ALIAS_DATA;
+        symbolTable.define(new Symbol(regNode.alias(), regNode.sourceInfo(), aliasType, regNode));
     }
 
     /**
-     * Validates that a register string represents a valid, non-forbidden register with an in-bounds index.
-     * Forbidden banks (FDR, FLR) are rejected — they cannot be aliased directly.
+     * Resolves a register string to its {@link RegisterBank}, validating syntax, bounds, and
+     * forbidden status. Returns {@code null} if the register is invalid.
      *
-     * @param registerText the register text to validate (e.g., "%DR0", "%PDR2", "%LR3")
-     * @return {@code true} if the register is syntactically valid, non-forbidden, and within bounds
+     * @param registerText the register text to resolve (e.g., "%DR0", "%PDR2", "%LR3")
+     * @return the matching bank, or {@code null} if invalid
      */
-    private boolean isValidRegister(String registerText) {
+    private RegisterBank resolveRegisterBank(String registerText) {
         if (registerText == null || !registerText.startsWith("%")) {
-            return false;
+            return null;
         }
         String upper = registerText.toUpperCase();
         try {
             for (RegisterBank bank : RegisterBank.values()) {
                 if (bank.count > 0 && !bank.isForbidden && upper.startsWith(bank.prefix)) {
                     int index = Integer.parseInt(upper.substring(bank.prefixLength));
-                    return index >= 0 && index < bank.count;
+                    if (index >= 0 && index < bank.count) {
+                        return bank;
+                    }
+                    return null;
                 }
             }
-            return false;
+            return null;
         } catch (NumberFormatException e) {
-            return false;
+            return null;
         }
     }
 }

--- a/src/main/java/org/evochora/compiler/features/require/RequireSymbolCollector.java
+++ b/src/main/java/org/evochora/compiler/features/require/RequireSymbolCollector.java
@@ -20,6 +20,6 @@ public class RequireSymbolCollector implements ISymbolCollector {
     @Override
     public void collect(AstNode node, SymbolTable symbolTable, DiagnosticsEngine diagnostics) {
         RequireNode requireNode = (RequireNode) node;
-        symbolTable.define(new Symbol(requireNode.alias(), requireNode.sourceInfo(), Symbol.Type.ALIAS, requireNode));
+        symbolTable.define(new Symbol(requireNode.alias(), requireNode.sourceInfo(), Symbol.Type.MODULE_ALIAS, requireNode));
     }
 }

--- a/src/main/java/org/evochora/compiler/frontend/irgen/IrGenContext.java
+++ b/src/main/java/org/evochora/compiler/frontend/irgen/IrGenContext.java
@@ -39,8 +39,6 @@ public final class IrGenContext {
 	private final DiagnosticsEngine diagnostics;
 	private final IrConverterRegistry registry;
 	private final List<IrItem> out = new ArrayList<>();
-	private final Deque<Map<String, Integer>> procParamScopes = new ArrayDeque<>();
-	private final Deque<Map<String, Integer>> procLocationParamScopes = new ArrayDeque<>();
 	private final Map<String, org.evochora.compiler.model.ir.IrOperand> constantByNameUpper = new HashMap<>();
 	private final Deque<String> aliasChainStack = new ArrayDeque<>();
 
@@ -97,69 +95,6 @@ public final class IrGenContext {
 		return new IrProgram(programName, List.copyOf(out));
 	}
 
-	// --- Procedure parameter scope management ---
-
-	/**
-	 * Pushes a new data parameter scope for a procedure (REF/VAL parameters → FDR).
-	 * @param params The list of data parameter names.
-	 */
-	public void pushProcedureParams(List<String> params) {
-		Map<String, Integer> map = new HashMap<>();
-		if (params != null) {
-			for (int i = 0; i < params.size(); i++) {
-				String name = params.get(i).toUpperCase();
-				map.put(name, i);
-			}
-		}
-		procParamScopes.push(map);
-	}
-
-	/**
-	 * Pops the current data parameter scope.
-	 */
-	public void popProcedureParams() {
-		if (!procParamScopes.isEmpty()) procParamScopes.pop();
-	}
-
-	/**
-	 * Pushes a new location parameter scope for a procedure (LREF/LVAL parameters → FLR).
-	 * @param params The list of location parameter names.
-	 */
-	public void pushProcedureLocationParams(List<String> params) {
-		Map<String, Integer> map = new HashMap<>();
-		if (params != null) {
-			for (int i = 0; i < params.size(); i++) {
-				String name = params.get(i).toUpperCase();
-				map.put(name, i);
-			}
-		}
-		procLocationParamScopes.push(map);
-	}
-
-	/**
-	 * Pops the current location parameter scope.
-	 */
-	public void popProcedureLocationParams() {
-		if (!procLocationParamScopes.isEmpty()) procLocationParamScopes.pop();
-	}
-
-	/**
-	 * Resolves a procedure parameter by name, returning the full register string.
-	 * Checks location parameters first (FLR), then data parameters (FDR).
-	 *
-	 * @param identifierUpper The upper-case identifier to resolve.
-	 * @return The full register string (e.g., "%FDR0" or "%FLR1"), or empty if not a parameter.
-	 */
-	public Optional<String> resolveProcedureParam(String identifierUpper) {
-		for (Map<String, Integer> scope : procLocationParamScopes) {
-			if (scope.containsKey(identifierUpper)) return Optional.of("%FLR" + scope.get(identifierUpper));
-		}
-		for (Map<String, Integer> scope : procParamScopes) {
-			if (scope.containsKey(identifierUpper)) return Optional.of("%FDR" + scope.get(identifierUpper));
-		}
-		return Optional.empty();
-	}
-
 	// --- Alias chain stack management ---
 
 	/**
@@ -204,8 +139,9 @@ public final class IrGenContext {
 
 	/**
 	 * Converts an AST operand node into its IR representation.
-	 * Handles registers, literals, identifiers (resolving procedure parameters,
-	 * constants, and label references), and vectors.
+	 * Handles registers, literals, identifiers (constants and label references),
+	 * and vectors. Parameter identifiers are already resolved to RegisterNodes
+	 * in Phase 6 and take the RegisterNode branch.
 	 *
 	 * @param node The AST node to convert.
 	 * @return The corresponding IR operand.
@@ -222,10 +158,6 @@ public final class IrGenContext {
 			return new IrVec(comps);
 		} else if (node instanceof IdentifierNode id) {
 			String nameU = id.text().toUpperCase();
-			Optional<String> paramRegOpt = resolveProcedureParam(nameU);
-			if (paramRegOpt.isPresent()) {
-				return new IrReg(paramRegOpt.get());
-			}
 			Optional<IrOperand> constOpt = resolveConstant(nameU);
 			if (constOpt.isPresent()) {
 				return constOpt.get();

--- a/src/main/java/org/evochora/compiler/frontend/postprocess/AstPostProcessor.java
+++ b/src/main/java/org/evochora/compiler/frontend/postprocess/AstPostProcessor.java
@@ -2,6 +2,7 @@ package org.evochora.compiler.frontend.postprocess;
 
 import org.evochora.compiler.frontend.TreeWalker;
 import org.evochora.compiler.model.ast.AstNode;
+import org.evochora.compiler.model.ast.IParameterBinding;
 import org.evochora.compiler.model.ast.IRegisterAlias;
 import org.evochora.compiler.model.ast.IdentifierNode;
 import org.evochora.compiler.model.ast.RegisterNode;
@@ -105,6 +106,11 @@ public class AstPostProcessor implements IPostProcessContext {
             if ((symbol.type() == Symbol.Type.REGISTER_ALIAS_DATA || symbol.type() == Symbol.Type.REGISTER_ALIAS_LOCATION)
                     && symbol.node() instanceof IRegisterAlias alias) {
                 createRegisterReplacement(idNode, identifierName.toUpperCase(), alias.register());
+                return;
+            }
+            if ((symbol.type() == Symbol.Type.PARAMETER_DATA || symbol.type() == Symbol.Type.PARAMETER_LOCATION)
+                    && symbol.node() instanceof IParameterBinding pb) {
+                createRegisterReplacement(idNode, identifierName.toUpperCase(), pb.targetRegister());
                 return;
             }
             if (symbol.type() == Symbol.Type.CONSTANT) {

--- a/src/main/java/org/evochora/compiler/frontend/postprocess/AstPostProcessor.java
+++ b/src/main/java/org/evochora/compiler/frontend/postprocess/AstPostProcessor.java
@@ -102,7 +102,8 @@ public class AstPostProcessor implements IPostProcessContext {
         Optional<ResolvedSymbol> symbolOpt = symbolTable.resolve(identifierName, idNode.sourceInfo().fileName());
         if (symbolOpt.isPresent()) {
             Symbol symbol = symbolOpt.get().symbol();
-            if (symbol.type() == Symbol.Type.ALIAS && symbol.node() instanceof IRegisterAlias alias) {
+            if ((symbol.type() == Symbol.Type.REGISTER_ALIAS_DATA || symbol.type() == Symbol.Type.REGISTER_ALIAS_LOCATION)
+                    && symbol.node() instanceof IRegisterAlias alias) {
                 createRegisterReplacement(idNode, identifierName.toUpperCase(), alias.register());
                 return;
             }

--- a/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenKindMapper.java
+++ b/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenKindMapper.java
@@ -22,7 +22,7 @@ public final class TokenKindMapper {
             case LABEL -> TokenKind.LABEL;
             case CONSTANT -> TokenKind.CONSTANT;
             case PROCEDURE -> TokenKind.PROCEDURE;
-            case VARIABLE, LOCATION_VARIABLE -> TokenKind.VARIABLE;
+            case PARAMETER_DATA, PARAMETER_LOCATION -> TokenKind.PARAMETER;
             case ALIAS -> TokenKind.ALIAS;
         };
     }

--- a/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenKindMapper.java
+++ b/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenKindMapper.java
@@ -23,7 +23,8 @@ public final class TokenKindMapper {
             case CONSTANT -> TokenKind.CONSTANT;
             case PROCEDURE -> TokenKind.PROCEDURE;
             case PARAMETER_DATA, PARAMETER_LOCATION -> TokenKind.PARAMETER;
-            case ALIAS -> TokenKind.ALIAS;
+            case REGISTER_ALIAS_DATA, REGISTER_ALIAS_LOCATION -> TokenKind.ALIAS;
+            case MODULE_ALIAS -> TokenKind.MODULE_ALIAS;
         };
     }
 }

--- a/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenMapGenerator.java
+++ b/src/main/java/org/evochora/compiler/frontend/tokenmap/TokenMapGenerator.java
@@ -219,7 +219,7 @@ public class TokenMapGenerator implements ITokenMapContext {
                 SourceInfo regSourceInfo = registerNode.sourceInfo();
                 tokenMap.put(regSourceInfo, new TokenInfo(
                     registerNode.getName(),
-                    TokenKind.VARIABLE,
+                    TokenKind.REGISTER,
                     this.currentScopeName
                 ));
             }

--- a/src/main/java/org/evochora/compiler/model/ast/IParameterBinding.java
+++ b/src/main/java/org/evochora/compiler/model/ast/IParameterBinding.java
@@ -1,0 +1,16 @@
+package org.evochora.compiler.model.ast;
+
+/**
+ * Capability interface for AST nodes that carry a parameter's target register binding.
+ * Used by the AstPostProcessor to resolve parameter identifiers to RegisterNodes
+ * without depending on specific feature node types.
+ */
+public interface IParameterBinding {
+
+    /**
+     * Returns the target formal register (e.g., "%FDR0", "%FLR1").
+     *
+     * @return the target register name, never null
+     */
+    String targetRegister();
+}

--- a/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
+++ b/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
@@ -1,6 +1,7 @@
 package org.evochora.compiler.model.ast;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Synthetic AST node carrying a parameter's compile-time register binding.
@@ -10,6 +11,10 @@ import java.util.List;
  * @param targetRegister The target formal register (e.g., "%FDR0", "%FLR1").
  */
 public record ParameterBinding(String targetRegister) implements AstNode, IParameterBinding {
+
+    public ParameterBinding {
+        Objects.requireNonNull(targetRegister, "targetRegister must not be null");
+    }
 
     @Override
     public List<AstNode> getChildren() {

--- a/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
+++ b/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
@@ -12,10 +12,16 @@ import java.util.Objects;
  */
 public record ParameterBinding(String targetRegister) implements AstNode, IParameterBinding {
 
+    /**
+     * @throws NullPointerException if {@code targetRegister} is null
+     */
     public ParameterBinding {
         Objects.requireNonNull(targetRegister, "targetRegister must not be null");
     }
 
+    /**
+     * Returns an empty list — this synthetic node has no children.
+     */
     @Override
     public List<AstNode> getChildren() {
         return List.of();

--- a/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
+++ b/src/main/java/org/evochora/compiler/model/ast/ParameterBinding.java
@@ -1,0 +1,18 @@
+package org.evochora.compiler.model.ast;
+
+import java.util.List;
+
+/**
+ * Synthetic AST node carrying a parameter's compile-time register binding.
+ * Created by ProcedureSymbolCollector and stored on the Symbol's node field.
+ * Not part of the parsed AST — exists solely as a data carrier for Phase 6 resolution.
+ *
+ * @param targetRegister The target formal register (e.g., "%FDR0", "%FLR1").
+ */
+public record ParameterBinding(String targetRegister) implements AstNode, IParameterBinding {
+
+    @Override
+    public List<AstNode> getChildren() {
+        return List.of();
+    }
+}

--- a/src/main/java/org/evochora/compiler/model/symbols/Symbol.java
+++ b/src/main/java/org/evochora/compiler/model/symbols/Symbol.java
@@ -24,10 +24,10 @@ public record Symbol(String name, SourceInfo sourceInfo, Type type, AstNode node
         CONSTANT,
         /** A procedure defined with .PROC. */
         PROCEDURE,
-        /** A data variable, such as a REF/VAL procedure parameter (resolves to FDR). */
-        VARIABLE,
-        /** A location variable, such as an LREF/LVAL procedure parameter (resolves to FLR). */
-        LOCATION_VARIABLE,
+        /** A data procedure parameter (REF/VAL, resolves to FDR). */
+        PARAMETER_DATA,
+        /** A location procedure parameter (LREF/LVAL, resolves to FLR). */
+        PARAMETER_LOCATION,
         /** A register alias defined with .REG. */
         ALIAS
     }

--- a/src/main/java/org/evochora/compiler/model/symbols/Symbol.java
+++ b/src/main/java/org/evochora/compiler/model/symbols/Symbol.java
@@ -28,8 +28,12 @@ public record Symbol(String name, SourceInfo sourceInfo, Type type, AstNode node
         PARAMETER_DATA,
         /** A location procedure parameter (LREF/LVAL, resolves to FLR). */
         PARAMETER_LOCATION,
-        /** A register alias defined with .REG. */
-        ALIAS
+        /** A module alias defined with .IMPORT AS or .REQUIRE AS. */
+        MODULE_ALIAS,
+        /** A data register alias (.REG %X %DR0, target is a data bank). */
+        REGISTER_ALIAS_DATA,
+        /** A location register alias (.REG %X %LR0, target is a location bank). */
+        REGISTER_ALIAS_LOCATION
     }
 
     /**

--- a/src/main/resources/web/visualizer/js/annotator/handlers/ParameterTokenHandler.js
+++ b/src/main/resources/web/visualizer/js/annotator/handlers/ParameterTokenHandler.js
@@ -23,10 +23,10 @@ export class ParameterTokenHandler {
             return false;
         }
         
-        const isVariableType = tokenInfo.tokenType === 'PARAMETER';
+        const isParameterType = tokenInfo.tokenType === 'PARAMETER';
         const isInProcedureScope = tokenInfo.scope && tokenInfo.scope.toUpperCase() !== 'GLOBAL';
         
-        return isVariableType && isInProcedureScope;
+        return isParameterType && isInProcedureScope;
     }
 
     /**

--- a/src/main/resources/web/visualizer/js/annotator/handlers/ParameterTokenHandler.js
+++ b/src/main/resources/web/visualizer/js/annotator/handlers/ParameterTokenHandler.js
@@ -12,18 +12,18 @@ import { ValueFormatter } from '../../utils/ValueFormatter.js';
 export class ParameterTokenHandler {
     /**
      * Determines if this handler can process the given token.
-     * It handles tokens identified as 'VARIABLE' type that are in a procedure scope (not global).
+     * It handles tokens identified as 'PARAMETER' type that are in a procedure scope (not global).
      *
      * @param {string} tokenText The text of the token.
      * @param {object} tokenInfo Metadata about the token from the compiler.
-     * @returns {boolean} True if the token is a 'VARIABLE' type in a procedure scope, false otherwise.
+     * @returns {boolean} True if the token is a 'PARAMETER' type in a procedure scope, false otherwise.
      */
     canHandle(tokenText, tokenInfo) {
         if (!tokenInfo) {
             return false;
         }
         
-        const isVariableType = tokenInfo.tokenType === 'VARIABLE';
+        const isVariableType = tokenInfo.tokenType === 'PARAMETER';
         const isInProcedureScope = tokenInfo.scope && tokenInfo.scope.toUpperCase() !== 'GLOBAL';
         
         return isVariableType && isInProcedureScope;

--- a/src/main/resources/web/visualizer/js/annotator/handlers/RegisterTokenHandler.js
+++ b/src/main/resources/web/visualizer/js/annotator/handlers/RegisterTokenHandler.js
@@ -9,7 +9,7 @@ import { ValueFormatter } from '../../utils/ValueFormatter.js';
 export class RegisterTokenHandler {
     /**
      * Determines if this handler can process the given token.
-     * It handles tokens identified as 'ALIAS' or 'VARIABLE' that start with '%'.
+     * It handles tokens identified as 'ALIAS' or 'REGISTER'.
      *
      * @param {string} tokenText The text of the token.
      * @param {object} tokenInfo Metadata about the token from the compiler.
@@ -17,7 +17,7 @@ export class RegisterTokenHandler {
      */
     canHandle(token, tokenInfo) {
         const type = tokenInfo.tokenType;
-        return type === 'ALIAS' || (type === 'VARIABLE' && token.startsWith('%'));
+        return type === 'ALIAS' || type === 'REGISTER';
     }
 
     /**

--- a/src/test/java/org/evochora/compiler/directives/DefineDirectiveTest.java
+++ b/src/test/java/org/evochora/compiler/directives/DefineDirectiveTest.java
@@ -1,6 +1,7 @@
 package org.evochora.compiler.directives;
 
 import org.evochora.compiler.diagnostics.DiagnosticsEngine;
+import org.evochora.compiler.model.ScopeTracker;
 import org.evochora.compiler.frontend.lexer.Lexer;
 import org.evochora.compiler.model.token.Token;
 import org.evochora.compiler.frontend.parser.Parser;
@@ -92,7 +93,7 @@ public class DefineDirectiveTest {
         semanticAnalyzer.analyze(ast);
 
         // AST Post-Processing - Resolves constants
-        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
         List<AstNode> processedAst = ast.stream()
             .map(node -> astPostProcessor.process(node))
             .toList();

--- a/src/test/java/org/evochora/compiler/directives/RegDirectiveTest.java
+++ b/src/test/java/org/evochora/compiler/directives/RegDirectiveTest.java
@@ -1,5 +1,6 @@
 package org.evochora.compiler.directives;
 
+import org.evochora.compiler.model.ScopeTracker;
 import org.evochora.runtime.Config;
 import org.evochora.compiler.frontend.lexer.Lexer;
 import org.evochora.compiler.frontend.parser.Parser;
@@ -67,7 +68,7 @@ public class RegDirectiveTest {
         semanticAnalyzer.analyze(ast);
 
         // AST Post-Processing - Resolves register aliases
-        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
         List<AstNode> processedAst = ast.stream()
             .map(node -> astPostProcessor.process(node))
             .toList();
@@ -228,7 +229,7 @@ public class RegDirectiveTest {
         SemanticAnalyzer semanticAnalyzer = new SemanticAnalyzer(diagnostics, symbolTable, null, null, null, TestRegistries.analysisRegistry(symbolTable, diagnostics), new org.evochora.compiler.frontend.semantics.ModuleSetupRegistry());
         semanticAnalyzer.analyze(ast);
 
-        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
         List<AstNode> processedAst = ast.stream()
             .map(node -> astPostProcessor.process(node))
             .toList();
@@ -300,7 +301,7 @@ public class RegDirectiveTest {
         semanticAnalyzer.analyze(ast);
 
         // AST Post-Processing - Resolves register aliases
-        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        AstPostProcessor astPostProcessor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
         List<AstNode> processedAst = ast.stream()
             .map(node -> astPostProcessor.process(node))
             .toList();

--- a/src/test/java/org/evochora/compiler/frontend/IrGeneratorTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/IrGeneratorTest.java
@@ -98,6 +98,16 @@ public class IrGeneratorTest {
             fail("Semantic analysis errors: " + diagnostics.summary());
         }
 
+        // Phase 6: AST Post-Processing (resolve register aliases and parameters)
+        org.evochora.compiler.model.ModuleContextTracker postTracker = new org.evochora.compiler.model.ModuleContextTracker(symbolTable);
+        org.evochora.compiler.model.ScopeTracker scopeTracker = new org.evochora.compiler.model.ScopeTracker(symbolTable);
+        symbolTable.setCurrentModule(rootAliasChain);
+        org.evochora.compiler.frontend.postprocess.AstPostProcessor postProcessor =
+                new org.evochora.compiler.frontend.postprocess.AstPostProcessor(symbolTable, postTracker, scopeTracker, TestRegistries.postProcessRegistry());
+        for (int i = 0; i < ast.size(); i++) {
+            ast.set(i, postProcessor.process(ast.get(i)));
+        }
+
         IrConverterRegistry registry = allConverters();
         IrGenerator irGen = new IrGenerator(diagnostics, registry);
         IrProgram ir = irGen.generate(ast, "TestProg", rootAliasChain);

--- a/src/test/java/org/evochora/compiler/frontend/postprocess/AstPostProcessorTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/postprocess/AstPostProcessorTest.java
@@ -1,5 +1,6 @@
 package org.evochora.compiler.frontend.postprocess;
 
+import org.evochora.compiler.model.ScopeTracker;
 import org.evochora.compiler.features.ctx.PushCtxNode;
 import org.evochora.compiler.features.ctx.PopCtxNode;
 import org.evochora.compiler.features.reg.RegNode;
@@ -44,15 +45,15 @@ class AstPostProcessorTest {
         symbolTable.registerModule("TEST", "test.s");
         symbolTable.setCurrentModule("TEST");
 
-        processor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        processor = new AstPostProcessor(symbolTable, new ModuleContextTracker(symbolTable), new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
 
-        // Register aliases as ALIAS symbols with RegNode on the Symbol's node field
+        // Register aliases as REGISTER_ALIAS_DATA symbols with RegNode on the Symbol's node field
         RegNode counterReg = new RegNode("COUNTER", "%DR0", createSourceInfo());
         RegNode tmpReg = new RegNode("TMP", "%PDR0", createSourceInfo());
         RegNode posReg = new RegNode("POS", "%DR1", createSourceInfo());
-        symbolTable.define(new Symbol("COUNTER", createSourceInfo(), Symbol.Type.ALIAS, counterReg));
-        symbolTable.define(new Symbol("TMP", createSourceInfo(), Symbol.Type.ALIAS, tmpReg));
-        symbolTable.define(new Symbol("POS", createSourceInfo(), Symbol.Type.ALIAS, posReg));
+        symbolTable.define(new Symbol("COUNTER", createSourceInfo(), Symbol.Type.REGISTER_ALIAS_DATA, counterReg));
+        symbolTable.define(new Symbol("TMP", createSourceInfo(), Symbol.Type.REGISTER_ALIAS_DATA, tmpReg));
+        symbolTable.define(new Symbol("POS", createSourceInfo(), Symbol.Type.REGISTER_ALIAS_DATA, posReg));
     }
 
     @Test
@@ -148,14 +149,14 @@ class AstPostProcessorTest {
     }
 
     @Test
-    void testProcess_AliasWithoutRegNode_NotReplacedInMainProcessor() {
-        // ALIAS symbol with no RegNode (node=null) — should NOT be replaced
+    void testProcess_ModuleAlias_NotReplaced() {
+        // MODULE_ALIAS symbol — should NOT be replaced (not a register alias)
         IdentifierNode idNode = new IdentifierNode("SOME_ALIAS", createSourceInfo());
-        symbolTable.define(new Symbol("SOME_ALIAS", createSourceInfo(), Symbol.Type.ALIAS));
+        symbolTable.define(new Symbol("SOME_ALIAS", createSourceInfo(), Symbol.Type.MODULE_ALIAS));
 
         AstNode result = processor.process(idNode);
 
-        // Should NOT be replaced (ALIAS but node is not IRegisterAlias)
+        // Should NOT be replaced (module alias, not register alias)
         assertThat(result).isSameAs(idNode);
     }
 
@@ -226,9 +227,9 @@ class AstPostProcessorTest {
         SymbolTable freshSt = new SymbolTable(freshDiags);
         freshSt.registerModule("TEST", "test.s");
         freshSt.setCurrentModule("TEST");
-        freshSt.define(new Symbol("ORPHAN", createSourceInfo(), Symbol.Type.ALIAS));
+        freshSt.define(new Symbol("ORPHAN", createSourceInfo(), Symbol.Type.MODULE_ALIAS));
 
-        AstPostProcessor freshProcessor = new AstPostProcessor(freshSt, new ModuleContextTracker(freshSt), new org.evochora.compiler.model.ScopeTracker(freshSt), TestRegistries.postProcessRegistry());
+        AstPostProcessor freshProcessor = new AstPostProcessor(freshSt, new ModuleContextTracker(freshSt), new ScopeTracker(freshSt), TestRegistries.postProcessRegistry());
 
         IdentifierNode idNode = new IdentifierNode("ORPHAN", createSourceInfo());
         AstNode result = freshProcessor.process(idNode);
@@ -319,7 +320,7 @@ class AstPostProcessorTest {
 
         // Use ModuleContextTracker with alias chains via PushCtxNode
         ModuleContextTracker tracker = new ModuleContextTracker(st);
-        AstPostProcessor moduleProcessor = new AstPostProcessor(st, tracker, new org.evochora.compiler.model.ScopeTracker(st), TestRegistries.postProcessRegistry());
+        AstPostProcessor moduleProcessor = new AstPostProcessor(st, tracker, new ScopeTracker(st), TestRegistries.postProcessRegistry());
 
         List<AstNode> nodes = List.of(
                 new PushCtxNode("/mod_a.evo", modAChain), defineA, instrA, new PopCtxNode(),

--- a/src/test/java/org/evochora/compiler/frontend/postprocess/RegisterAliasScopeTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/postprocess/RegisterAliasScopeTest.java
@@ -65,13 +65,13 @@ class RegisterAliasScopeTest {
         symbolTable.define(new Symbol("PROC_A", SRC, Symbol.Type.PROCEDURE, procA));
         SymbolTable.Scope scopeA = symbolTable.enterScope("PROC_A");
         symbolTable.registerNodeScope(procA, scopeA);
-        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.ALIAS, regA));
+        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.REGISTER_ALIAS_DATA, regA));
         symbolTable.leaveScope();
 
         symbolTable.define(new Symbol("PROC_B", SRC, Symbol.Type.PROCEDURE, procB));
         SymbolTable.Scope scopeB = symbolTable.enterScope("PROC_B");
         symbolTable.registerNodeScope(procB, scopeB);
-        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.ALIAS, regB));
+        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.REGISTER_ALIAS_DATA, regB));
         symbolTable.leaveScope();
 
         // Process
@@ -101,7 +101,7 @@ class RegisterAliasScopeTest {
         RegNode moduleReg = new RegNode("X", "%DR0", SRC);
         RegNode procReg = new RegNode("X", "%PDR0", SRC);
 
-        symbolTable.define(new Symbol("X", SRC, Symbol.Type.ALIAS, moduleReg));
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_DATA, moduleReg));
 
         IdentifierNode useOutside = new IdentifierNode("X", SRC);
         IdentifierNode useInside = new IdentifierNode("X", SRC);
@@ -113,7 +113,7 @@ class RegisterAliasScopeTest {
         symbolTable.define(new Symbol("MY_PROC", SRC, Symbol.Type.PROCEDURE, proc));
         SymbolTable.Scope procScope = symbolTable.enterScope("MY_PROC");
         symbolTable.registerNodeScope(proc, procScope);
-        symbolTable.define(new Symbol("X", SRC, Symbol.Type.ALIAS, procReg));
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_DATA, procReg));
         symbolTable.leaveScope();
 
         AstPostProcessor processor = createProcessor();
@@ -136,7 +136,7 @@ class RegisterAliasScopeTest {
         // Module-level: .REG %GLOBAL %DR7
         // Proc: no .REG for GLOBAL — should inherit from module scope
         RegNode moduleReg = new RegNode("GLOBAL", "%DR7", SRC);
-        symbolTable.define(new Symbol("GLOBAL", SRC, Symbol.Type.ALIAS, moduleReg));
+        symbolTable.define(new Symbol("GLOBAL", SRC, Symbol.Type.REGISTER_ALIAS_DATA, moduleReg));
 
         IdentifierNode useInProc = new IdentifierNode("GLOBAL", SRC);
         InstructionNode instrInProc = new InstructionNode("SETI", List.of(useInProc), SRC);

--- a/src/test/java/org/evochora/compiler/frontend/postprocess/RegisterAliasScopeTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/postprocess/RegisterAliasScopeTest.java
@@ -10,6 +10,7 @@ import org.evochora.compiler.model.ScopeTracker;
 import org.evochora.compiler.model.ast.AstNode;
 import org.evochora.compiler.model.ast.IdentifierNode;
 import org.evochora.compiler.model.ast.InstructionNode;
+import org.evochora.compiler.model.ast.ParameterBinding;
 import org.evochora.compiler.model.ast.RegisterNode;
 import org.evochora.compiler.model.symbols.Symbol;
 import org.evochora.compiler.model.symbols.SymbolTable;
@@ -157,6 +158,33 @@ class RegisterAliasScopeTest {
         InstructionNode resultInstr = (InstructionNode) resultProc.body().get(0);
         assertThat(resultInstr.arguments().get(0)).isInstanceOf(RegisterNode.class);
         assertThat(((RegisterNode) resultInstr.arguments().get(0)).getName()).isEqualTo("%DR7");
+    }
+
+    @Test
+    void parameterResolvedInsideProc() {
+        // Proc with REF param "X" — inside proc, X should resolve to %FDR0
+        IdentifierNode useInProc = new IdentifierNode("X", SRC);
+        InstructionNode instrInProc = new InstructionNode("SETI", List.of(useInProc), SRC);
+
+        ProcedureNode proc = new ProcedureNode("MY_PROC", false,
+                List.of(new ProcedureNode.ParamDecl("X", SRC)),
+                List.of(), List.of(), List.of(),
+                List.of(instrInProc), SRC);
+
+        symbolTable.define(new Symbol("MY_PROC", SRC, Symbol.Type.PROCEDURE, proc));
+        SymbolTable.Scope procScope = symbolTable.enterScope("MY_PROC");
+        symbolTable.registerNodeScope(proc, procScope);
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.PARAMETER_DATA,
+                new ParameterBinding("%FDR0")));
+        symbolTable.leaveScope();
+
+        AstPostProcessor processor = createProcessor();
+        AstNode procResult = processor.process(proc);
+
+        ProcedureNode resultProc = (ProcedureNode) procResult;
+        InstructionNode resultInstr = (InstructionNode) resultProc.body().get(0);
+        assertThat(resultInstr.arguments().get(0)).isInstanceOf(RegisterNode.class);
+        assertThat(((RegisterNode) resultInstr.arguments().get(0)).getName()).isEqualTo("%FDR0");
     }
 
     private AstPostProcessor createProcessor() {

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/CallAnalysisHandlerTypeSafetyTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/CallAnalysisHandlerTypeSafetyTest.java
@@ -131,6 +131,30 @@ class CallAnalysisHandlerTypeSafetyTest {
     }
 
     @Test
+    void labelAsRef_reportsError() {
+        symbolTable.define(new Symbol("MY_LABEL", SRC, Symbol.Type.LABEL));
+
+        CallNode call = callWithRef("MY_LABEL");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("must resolve to a data register"))).isTrue();
+    }
+
+    @Test
+    void constantAsLref_reportsError() {
+        symbolTable.define(new Symbol("MY_CONST", SRC, Symbol.Type.CONSTANT));
+
+        CallNode call = callWithLref("MY_CONST");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("must resolve to a location register"))).isTrue();
+    }
+
+    @Test
     void moduleAliasAsRef_reportsError() {
         symbolTable.define(new Symbol("MATH", SRC, Symbol.Type.MODULE_ALIAS));
 

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/CallAnalysisHandlerTypeSafetyTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/CallAnalysisHandlerTypeSafetyTest.java
@@ -1,0 +1,211 @@
+package org.evochora.compiler.frontend.semantics.analysis;
+
+import org.evochora.compiler.api.SourceInfo;
+import org.evochora.compiler.diagnostics.DiagnosticsEngine;
+import org.evochora.compiler.features.proc.CallAnalysisHandler;
+import org.evochora.compiler.features.proc.CallNode;
+import org.evochora.compiler.features.proc.ProcedureNode;
+import org.evochora.compiler.features.reg.RegNode;
+import org.evochora.compiler.model.ast.IdentifierNode;
+import org.evochora.compiler.model.ast.RegisterNode;
+import org.evochora.compiler.model.symbols.Symbol;
+import org.evochora.compiler.model.symbols.SymbolTable;
+import org.evochora.runtime.isa.Instruction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for symbol type validation in {@link CallAnalysisHandler}.
+ * Verifies that data register aliases are only accepted in REF/VAL positions,
+ * location register aliases only in LREF/LVAL positions, and module aliases
+ * are always rejected.
+ */
+@Tag("unit")
+class CallAnalysisHandlerTypeSafetyTest {
+
+    private CallAnalysisHandler handler;
+    private SymbolTable symbolTable;
+    private DiagnosticsEngine diagnostics;
+
+    private static final SourceInfo SRC = new SourceInfo("test.s", 1, 0);
+
+    @BeforeAll
+    static void initInstructionSet() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new CallAnalysisHandler();
+        diagnostics = new DiagnosticsEngine();
+        symbolTable = new SymbolTable(diagnostics);
+        symbolTable.registerModule("TEST", "test.s");
+        symbolTable.setCurrentModule("TEST");
+
+        // Define a procedure with 1 REF param and 1 LREF param
+        ProcedureNode proc = new ProcedureNode("MY_PROC", true,
+                List.of(new ProcedureNode.ParamDecl("R", SRC)),
+                List.of(),
+                List.of(new ProcedureNode.ParamDecl("L", SRC)),
+                List.of(),
+                List.of(), SRC);
+        symbolTable.define(new Symbol("MY_PROC", SRC, Symbol.Type.PROCEDURE, proc, true));
+    }
+
+    @Test
+    void dataAliasAsRef_noError() {
+        RegNode reg = new RegNode("X", "%DR0", SRC);
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_DATA, reg));
+
+        CallNode call = callWithRef("X");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isFalse();
+    }
+
+    @Test
+    void locationAliasAsLref_noError() {
+        RegNode reg = new RegNode("X", "%LR0", SRC);
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_LOCATION, reg));
+
+        CallNode call = callWithLref("X");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isFalse();
+    }
+
+    @Test
+    void dataAliasAsLref_reportsError() {
+        RegNode reg = new RegNode("X", "%DR0", SRC);
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_DATA, reg));
+
+        CallNode call = callWithLref("X");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("data register alias"))).isTrue();
+    }
+
+    @Test
+    void locationAliasAsRef_reportsError() {
+        RegNode reg = new RegNode("X", "%LR0", SRC);
+        symbolTable.define(new Symbol("X", SRC, Symbol.Type.REGISTER_ALIAS_LOCATION, reg));
+
+        CallNode call = callWithRef("X");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("location register alias"))).isTrue();
+    }
+
+    @Test
+    void dataParameterAsLref_reportsError() {
+        symbolTable.define(new Symbol("P", SRC, Symbol.Type.PARAMETER_DATA));
+
+        CallNode call = callWithLref("P");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("data parameter"))).isTrue();
+    }
+
+    @Test
+    void locationParameterAsRef_reportsError() {
+        symbolTable.define(new Symbol("P", SRC, Symbol.Type.PARAMETER_LOCATION));
+
+        CallNode call = callWithRef("P");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("location parameter"))).isTrue();
+    }
+
+    @Test
+    void moduleAliasAsRef_reportsError() {
+        symbolTable.define(new Symbol("MATH", SRC, Symbol.Type.MODULE_ALIAS));
+
+        CallNode call = callWithRef("MATH");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("Module alias"))).isTrue();
+    }
+
+    @Test
+    void moduleAliasAsLref_reportsError() {
+        symbolTable.define(new Symbol("MATH", SRC, Symbol.Type.MODULE_ALIAS));
+
+        CallNode call = callWithLref("MATH");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("Module alias"))).isTrue();
+    }
+
+    @Test
+    void unresolvedIdentifierAsRef_reportsError() {
+        CallNode call = callWithRef("UNKNOWN");
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("not defined"))).isTrue();
+    }
+
+    @Test
+    void unresolvedIdentifierAsVal_noError() {
+        // Redefine proc with 1 VAL param instead of REF
+        ProcedureNode proc = new ProcedureNode("VAL_PROC", true,
+                List.of(),
+                List.of(new ProcedureNode.ParamDecl("V", SRC)),
+                List.of(),
+                List.of(),
+                List.of(), SRC);
+        symbolTable.define(new Symbol("VAL_PROC", SRC, Symbol.Type.PROCEDURE, proc, true));
+
+        CallNode call = new CallNode(
+                new IdentifierNode("VAL_PROC", SRC),
+                List.of(),
+                List.of(new IdentifierNode("SOME_LABEL", SRC)),
+                List.of(),
+                List.of(),
+                SRC);
+        handler.analyze(call, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isFalse();
+    }
+
+    private CallNode callWithRef(String argName) {
+        // MY_PROC has 1 REF + 1 LREF — provide a dummy LREF to satisfy count validation
+        return new CallNode(
+                new IdentifierNode("MY_PROC", SRC),
+                List.of(new IdentifierNode(argName, SRC)),
+                List.of(),
+                List.of(new RegisterNode("%LR0", SRC)),
+                List.of(),
+                SRC);
+    }
+
+    private CallNode callWithLref(String argName) {
+        // MY_PROC has 1 REF + 1 LREF — provide a dummy REF to satisfy count validation
+        return new CallNode(
+                new IdentifierNode("MY_PROC", SRC),
+                List.of(new RegisterNode("%DR0", SRC)),
+                List.of(),
+                List.of(new IdentifierNode(argName, SRC)),
+                List.of(),
+                SRC);
+    }
+}

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/InstructionAnalysisHandlerAliasTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/InstructionAnalysisHandlerAliasTest.java
@@ -1,0 +1,124 @@
+package org.evochora.compiler.frontend.semantics.analysis;
+
+import org.evochora.compiler.api.SourceInfo;
+import org.evochora.compiler.diagnostics.DiagnosticsEngine;
+import org.evochora.compiler.features.instruction.InstructionAnalysisHandler;
+import org.evochora.compiler.features.reg.RegNode;
+import org.evochora.compiler.model.ast.IdentifierNode;
+import org.evochora.compiler.model.ast.InstructionNode;
+import org.evochora.compiler.model.ast.TypedLiteralNode;
+import org.evochora.compiler.model.symbols.Symbol;
+import org.evochora.compiler.model.symbols.SymbolTable;
+import org.evochora.runtime.isa.Instruction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for register alias and module alias type safety in {@link InstructionAnalysisHandler}.
+ * Verifies that data register aliases are only accepted in REGISTER positions, location
+ * register aliases only in LOCATION_REGISTER positions, and module aliases are always rejected.
+ */
+@Tag("unit")
+class InstructionAnalysisHandlerAliasTest {
+
+    private InstructionAnalysisHandler handler;
+    private SymbolTable symbolTable;
+    private DiagnosticsEngine diagnostics;
+
+    private static final SourceInfo SRC = new SourceInfo("test.s", 1, 0);
+
+    @BeforeAll
+    static void initInstructionSet() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new InstructionAnalysisHandler();
+        diagnostics = new DiagnosticsEngine();
+        symbolTable = new SymbolTable(diagnostics);
+        symbolTable.registerModule("TEST", "test.s");
+        symbolTable.setCurrentModule("TEST");
+    }
+
+    @Test
+    void dataAliasInDataInstruction_noError() {
+        RegNode regNode = new RegNode("COUNTER", "%DR0", SRC);
+        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.REGISTER_ALIAS_DATA, regNode));
+
+        // SETI expects (REGISTER, IMMEDIATE)
+        InstructionNode instr = new InstructionNode("SETI",
+                List.of(new IdentifierNode("COUNTER", SRC), new TypedLiteralNode("DATA", 42, SRC)), SRC);
+
+        handler.analyze(instr, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isFalse();
+    }
+
+    @Test
+    void locationAliasInLocationInstruction_noError() {
+        RegNode regNode = new RegNode("POS", "%LR0", SRC);
+        symbolTable.define(new Symbol("POS", SRC, Symbol.Type.REGISTER_ALIAS_LOCATION, regNode));
+
+        // SKLR expects (LOCATION_REGISTER)
+        InstructionNode instr = new InstructionNode("SKLR",
+                List.of(new IdentifierNode("POS", SRC)), SRC);
+
+        handler.analyze(instr, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isFalse();
+    }
+
+    @Test
+    void locationAliasInDataInstruction_reportsError() {
+        RegNode regNode = new RegNode("POS", "%LR0", SRC);
+        symbolTable.define(new Symbol("POS", SRC, Symbol.Type.REGISTER_ALIAS_LOCATION, regNode));
+
+        // SETI expects (REGISTER, IMMEDIATE) — location alias in REGISTER position is wrong
+        InstructionNode instr = new InstructionNode("SETI",
+                List.of(new IdentifierNode("POS", SRC), new TypedLiteralNode("DATA", 42, SRC)), SRC);
+
+        handler.analyze(instr, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("location register alias"))).isTrue();
+    }
+
+    @Test
+    void dataAliasInLocationInstruction_reportsError() {
+        RegNode regNode = new RegNode("COUNTER", "%DR0", SRC);
+        symbolTable.define(new Symbol("COUNTER", SRC, Symbol.Type.REGISTER_ALIAS_DATA, regNode));
+
+        // CRLR expects (LOCATION_REGISTER) — data alias in LOCATION_REGISTER position is wrong
+        InstructionNode instr = new InstructionNode("CRLR",
+                List.of(new IdentifierNode("COUNTER", SRC)), SRC);
+
+        handler.analyze(instr, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("data register alias"))).isTrue();
+    }
+
+    @Test
+    void moduleAliasInInstruction_reportsError() {
+        symbolTable.define(new Symbol("MATH", SRC, Symbol.Type.MODULE_ALIAS));
+
+        // SETI expects (REGISTER, IMMEDIATE) — module alias is never valid
+        InstructionNode instr = new InstructionNode("SETI",
+                List.of(new IdentifierNode("MATH", SRC), new TypedLiteralNode("DATA", 42, SRC)), SRC);
+
+        handler.analyze(instr, symbolTable, diagnostics);
+
+        assertThat(diagnostics.hasErrors()).isTrue();
+        assertThat(diagnostics.getDiagnostics().stream()
+                .anyMatch(d -> d.message().contains("Module alias"))).isTrue();
+    }
+}

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/RegAnalysisHandlerTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/RegAnalysisHandlerTest.java
@@ -41,7 +41,7 @@ class RegAnalysisHandlerTest {
 
         assertFalse(diagnostics.hasErrors());
         assertTrue(symbolTable.resolve("COUNTER", "test.s").isPresent());
-        assertEquals(Symbol.Type.ALIAS, symbolTable.resolve("COUNTER", "test.s").get().symbol().type());
+        assertEquals(Symbol.Type.REGISTER_ALIAS_DATA, symbolTable.resolve("COUNTER", "test.s").get().symbol().type());
     }
 
     @Test
@@ -52,7 +52,7 @@ class RegAnalysisHandlerTest {
 
         assertFalse(diagnostics.hasErrors());
         assertTrue(symbolTable.resolve("POSITION", "test.s").isPresent());
-        assertEquals(Symbol.Type.ALIAS, symbolTable.resolve("POSITION", "test.s").get().symbol().type());
+        assertEquals(Symbol.Type.REGISTER_ALIAS_LOCATION, symbolTable.resolve("POSITION", "test.s").get().symbol().type());
     }
 
     @Test
@@ -93,7 +93,7 @@ class RegAnalysisHandlerTest {
 
         assertFalse(diagnostics.hasErrors());
         assertTrue(symbolTable.resolve("TMP", "test.s").isPresent());
-        assertEquals(Symbol.Type.ALIAS, symbolTable.resolve("TMP", "test.s").get().symbol().type());
+        assertEquals(Symbol.Type.REGISTER_ALIAS_DATA, symbolTable.resolve("TMP", "test.s").get().symbol().type());
     }
 
     @Test

--- a/src/test/java/org/evochora/compiler/module/ModuleSourceDefineIntegrationTest.java
+++ b/src/test/java/org/evochora/compiler/module/ModuleSourceDefineIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.evochora.compiler.module;
 
 import org.evochora.compiler.FeatureRegistry;
+import org.evochora.compiler.model.ScopeTracker;
 import org.evochora.compiler.StandardFeatures;
 import org.evochora.compiler.api.SourceRoot;
 import org.evochora.compiler.diagnostics.DiagnosticsEngine;
@@ -366,7 +367,7 @@ class ModuleSourceDefineIntegrationTest {
         // Phase 6: AST Post-Processing (skip Phase 5 TokenMap — not needed for these tests)
         ModuleContextTracker tracker = new ModuleContextTracker(symbolTable);
         symbolTable.setCurrentModule(rootAliasChain);
-        AstPostProcessor postProcessor = new AstPostProcessor(symbolTable, tracker, new org.evochora.compiler.model.ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
+        AstPostProcessor postProcessor = new AstPostProcessor(symbolTable, tracker, new ScopeTracker(symbolTable), TestRegistries.postProcessRegistry());
         for (int i = 0; i < ast.size(); i++) {
             ast.set(i, postProcessor.process(ast.get(i)));
         }


### PR DESCRIPTION
## Summary

According to /docs/proposals/PARAMETER_RESOLUTION_CLEANUP.md

  - **Symbol Type Rename**: `VARIABLE`/`LOCATION_VARIABLE` → `PARAMETER_DATA`/`PARAMETER_LOCATION`, `ALIAS` →
  `REGISTER_ALIAS_DATA`/`REGISTER_ALIAS_LOCATION`/`MODULE_ALIAS` — explicit names, no ambiguity
  - **Register Alias Type Safety**: data aliases accepted only in REGISTER positions, location aliases only in LOCATION_REGISTER
  positions. Previously `.REG %POS %LR0` + `SETI %POS 42` compiled silently but crashed at runtime
  - **Module Alias Separation**: `.IMPORT`/`.REQUIRE` aliases get their own `MODULE_ALIAS` symbol type, rejected in instruction and
  CALL argument positions (previously shared type with register aliases)
  - **CALL Argument Validation**: symbol type resolution for all identifier arguments in REF/VAL/LREF/LVAL positions — data symbols in
  location positions and vice versa are now compile-time errors
  - **Parameter Resolution moved to Phase 6**: parameters resolved via SymbolTable + IParameterBinding in AstPostProcessor (same
  mechanism as register aliases), eliminating the duplicate scope stack in IrGenContext (~60 lines deleted)

  ## Motivation

  Four architectural issues addressed:
  1. `Symbol.Type.ALIAS` conflated register aliases and module aliases — no type safety, module aliases silently accepted in register
  positions
  2. Register aliases accepted in both REGISTER and LOCATION_REGISTER positions — runtime crashes instead of compile-time errors
  3. `VARIABLE`/`LOCATION_VARIABLE` naming misleading for procedure parameters
  4. IrGenContext maintained a parallel scope stack (`procParamScopes`/`procLocationParamScopes`) duplicating the SymbolTable's scope
  management — Single Source of Truth violation

  ## Implementation

  Four vertical steps, each independently compilable and testable:

  | Step | Scope | Key Changes |
  |------|-------|-------------|
  | 1 | Parameter Rename | Symbol.Type + TokenKind + all references + visualizer |
  | 2 | Alias Type Split | RegAnalysisHandler bank detection, InstructionAnalysisHandler type safety, Import/RequireSymbolCollector →
  MODULE_ALIAS |
  | 3 | CALL Validation | CallAnalysisHandler symbol resolution for identifier arguments |
  | 4 | Parameter Resolution | IParameterBinding + ParameterBinding, AstPostProcessor resolution, IrGenContext cleanup |

  ## Symbol Type Table (after)

  | Symbol.Type | Instruction Position | CALL Position | TokenKind |
  |---|---|---|---|
  | REGISTER_ALIAS_DATA | REGISTER only | REF/VAL only | ALIAS |
  | REGISTER_ALIAS_LOCATION | LOCATION_REGISTER only | LREF/LVAL only | ALIAS |
  | MODULE_ALIAS | Rejected | Rejected | MODULE_ALIAS |
  | PARAMETER_DATA | REGISTER only | REF/VAL only | PARAMETER |
  | PARAMETER_LOCATION | LOCATION_REGISTER only | LREF/LVAL only | PARAMETER |

  ## Test plan

  - [ ] `InstructionAnalysisHandlerAliasTest`: 5 tests — data/location alias type safety + module alias rejection
  - [ ] `CallAnalysisHandlerTypeSafetyTest`: 10 tests — alias/parameter/module type safety in CALL positions
  - [ ] `RegisterAliasScopeTest.parameterResolvedInsideProc`: parameter → RegisterNode via Phase 6
  - [ ] `RegAnalysisHandlerTest`: DATA vs LOCATION type assignment verified
  - [ ] `AstPostProcessorTest`: MODULE_ALIAS not resolved as register alias
  - [ ] `IrGeneratorTest`: Phase 6 post-processing before Phase 7
  - [ ] All existing tests green (no behavioral regression)
  - [ ] 5 CLI smoke tests green (primordial, simple, complex, modules, test)
  - [ ] `grep -r 'procParamScopes\|resolveProcedureParam' src/` returns 0 matches

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Proposal updated to "Symbol Type Safety" with four concrete resolution steps and revised symbol-type table.
* **New Features**
  * Tokenization/visualizer now distinguishes parameters, registers, and module aliases; parameters are resolved earlier into register references.
* **Bug Fixes**
  * Stricter validation and clearer diagnostics for call arguments and instruction operands (parameter vs register vs module alias mismatches).
* **Refactor**
  * Symbol categories reorganized; parameter resolution moved earlier in the pipeline.
* **Tests**
  * Added and updated tests for alias/parameter type-safety and post-processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->