### PR TITLE
Make an unusable resource visible, and stop scanning the organisms table three times per snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,10 +204,10 @@ runtime      →  (nothing)
 
 **Error Handling & Logging**:
 - **Transient Errors** (service/resource continues): `log.warn("msg", args)` + `recordError(code, msg, details)` - throw only if the caller must handle the failed operation
-- **Fatal Errors** (service/resource cannot serve any caller): `log.error("msg", args)` - NO exception parameter - `recordError(code, msg, details)` + THROW exception. Recording is required: a resource does not stop itself, so its state is invisible unless it is recorded
+- **Fatal Errors** (service/resource cannot serve any caller): `log.error("msg", args)` - `recordError(code, msg, details)` + THROW exception. Recording is required: a resource does not stop itself, so its state is invisible unless it is recorded
 - **Normal Shutdown** (InterruptedException): `log.debug("msg", args)` - re-throw exception - NO recordError()
 - **Retry Logic**: Use `log.debug()` during retries, then follow transient/fatal rules after exhaustion
-- **Stack Traces**: NEVER use `log.error(..., exception)` - stack traces logged at DEBUG level by framework
+- **Stack Traces**: pass the exception ONLY for bugs and system faults (see below) - never for expected errors
 - **Health Status**: Services/Resources are unhealthy if `errors.isEmpty() == false` or state == ERROR
 - **No Fallbacks**: Never hide problematic states or errors with fallback behavior — always fail early!
 
@@ -333,10 +333,13 @@ See `.agents/architecture-guidelines.md` for full review criteria.
 **Stack Traces:**
 - **Expected errors** (configuration, user input, known failure modes): NO stack trace
   - `log.warn("msg", args)` or `log.error("msg", args)` without exception parameter
-  - Stack trace available at DEBUG level if needed for support
-- **Unexpected errors / Bugs** (invariant violations, should-never-happen conditions): WITH stack trace
+  - A stack trace adds nothing: the message already states the cause
+- **Bugs** (invariant violations, should-never-happen conditions): WITH stack trace
   - `log.error("msg", args, new IllegalStateException("Invariant violation"))`
   - These indicate bugs that need immediate attention and debugging
+- **System faults** (cause lies outside the application: pool cannot create connections, storage gone, broker unreachable): WITH stack trace
+  - `log.error("msg", args, exception)` - the chained causes carry the diagnosis, and no message can replace them
+  - At ERROR, not DEBUG: production runs at INFO, and a cause that is only visible at DEBUG is not visible when it matters
 - For transient errors: `log.warn("msg", args)` without exception parameter
 - For fatal errors: `log.error("msg", args)` then throw exception
 - For interruption/shutdown: `log.debug("msg", args)` then re-throw

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,8 @@ runtime      →  (nothing)
 - **Atomic Artifacts**: All created artifacts must be created atomically to ensure resume functionality can always start from final artifacts
 
 **Error Handling & Logging**:
-- **Transient Errors** (service/resource continues): `log.warn("msg", args)` + `recordError(code, msg, details)` - NO exception thrown
-- **Fatal Errors** (service/resource must stop): `log.error("msg", args)` - NO exception parameter - THROW exception
+- **Transient Errors** (service/resource continues): `log.warn("msg", args)` + `recordError(code, msg, details)` - throw only if the caller must handle the failed operation
+- **Fatal Errors** (service/resource cannot serve any caller): `log.error("msg", args)` - NO exception parameter - `recordError(code, msg, details)` + THROW exception. Recording is required: a resource does not stop itself, so its state is invisible unless it is recorded
 - **Normal Shutdown** (InterruptedException): `log.debug("msg", args)` - re-throw exception - NO recordError()
 - **Retry Logic**: Use `log.debug()` during retries, then follow transient/fatal rules after exhaustion
 - **Stack Traces**: NEVER use `log.error(..., exception)` - stack traces logged at DEBUG level by framework
@@ -321,7 +321,7 @@ See `.agents/architecture-guidelines.md` for full review criteria.
 **Resources (DEBUG-only operations, WARN/ERROR for problems):**
 - `INFO`: NEVER log at INFO level (all orchestration goes through ServiceManager)
 - `WARN`: Transient operational errors (query failed, parse error, rollback failed, claim conflict reassignment, sampler errors) - always with `recordError()`
-- `ERROR`: Fatal initialization errors (connection pool failed, delegate creation failed, schema setup failed)
+- `ERROR`: Fatal errors (connection pool failed, delegate creation failed, schema setup failed, connection acquisition failed) - always with `recordError()`
 - `DEBUG`: All operations (connection pool started/closed, schema setup, delegate creation, message claim/ack, wrapper close, compression setup, sampling)
 
 **Format:**

--- a/docs/outdated/proposals/accomplished/GENOME_LINEAGE_INDEXING.md
+++ b/docs/outdated/proposals/accomplished/GENOME_LINEAGE_INDEXING.md
@@ -1,6 +1,12 @@
 # Organism Snapshot Cost: Ancestor Closures and Stored Tick Statistics
 
-**Status: TO BE REVIEWED — agreed approach for [#114](https://github.com/evochora/evochora/issues/114).**
+**Status: ACCOMPLISHED — implemented on branch `fix/113-record-connection-failures` (PR #118), 2026-08-26.**
+
+The read paths were verified against a copy of the production database: the static fields of 4 604
+organisms across seven ticks, the stored organism total at six ticks over six orders of magnitude,
+and the ancestor relation seeded with all 150 525 genomes of the run, which agrees with the old
+full-tree query entry for entry in both directions. The browser check ran on short runs produced by
+the current build; the published run could not serve it, for the reason recorded under step 8.
 
 ## Problem
 
@@ -358,7 +364,7 @@ guard in `_applyGenomeLineageTree`.
 Out of scope. No detection, no migration, no fallback — a database written before this change lacks
 the stored per-tick total, and the organisms endpoint fails for it the way any schema change fails
 today. Making format mismatches explicit is the subject of
-[PERSISTED_FORMAT_VERSIONING](PERSISTED_FORMAT_VERSIONING.md).
+[PERSISTED_FORMAT_VERSIONING](../../../proposals/PERSISTED_FORMAT_VERSIONING.md).
 
 ### Points checked and deliberately not changed
 
@@ -422,7 +428,7 @@ automated tests. It is verified by hand in step 8, as frontend changes are today
 The published run cannot serve this purpose, and the reason is worth recording. Its organism blobs
 were written in February 2026, before commit `8919f646` renumbered the fields of `OrganismState`;
 a current build fails to parse them with *"Protocol message had invalid UTF-8"*, which is the exact
-consequence [PERSISTED_FORMAT_VERSIONING](PERSISTED_FORMAT_VERSIONING.md) records as evidence. The
+consequence [PERSISTED_FORMAT_VERSIONING](../../../proposals/PERSISTED_FORMAT_VERSIONING.md) records as evidence. The
 demo node serves that run only because its image predates the renumbering. This is independent of
 this change and blocks any browser check against existing data.
 

--- a/docs/proposals/GENOME_LINEAGE_INDEXING.md
+++ b/docs/proposals/GENOME_LINEAGE_INDEXING.md
@@ -1,0 +1,418 @@
+# Organism Snapshot Cost: Ancestor Closures and Stored Tick Statistics
+
+**Status: TO BE REVIEWED — agreed approach for [#114](https://github.com/evochora/evochora/issues/114).**
+
+## Problem
+
+Every `GET /visualizer/api/organisms/{tick}` request scans the whole `organisms` table three times:
+once into a map of all organisms ever created, once for a `MAX` over an unindexed column, and once
+through a self-join that recomputes the complete genome lineage tree. On run
+`20260226-03114337` — 14 644 315 organisms, 150 526 genomes — a single tick change costs tens of
+seconds of CPU and carries a 6.6 MB tree in the response. All three reads scale with the total size
+of the run, not with what the tick shows.
+
+The heap peak of the first read is the practical trigger of [#113](https://github.com/evochora/evochora/issues/113):
+concurrent requests exhausted the 16 GB heap on the demo node, and the resulting `OutOfMemoryError`
+inside an H2 store operation killed the embedded database for the lifetime of the process.
+
+## What one request does today
+
+| Step | Query | Cost |
+|---|---|---|
+| `readOrganismsBlobForTick` | one row of `organism_ticks` by primary key, zstd-decompressed | proportional to the tick |
+| `readAllStaticInfo` | `SELECT organism_id, parent_id, birth_tick, genome_hash FROM organisms` — no `WHERE` | full scan, all rows into a `HashMap` |
+| `readTotalOrganismsCreated` | `SELECT MAX(organism_id) FROM organisms WHERE birth_tick <= ?` | full scan, constant memory |
+| `readGenomeLineageTree` | self-join of `organisms` with itself, `ORDER BY organism_id` | full scan, join, sort, up to 150 k entries |
+
+HTTP caching is disabled by default for this endpoint (`reference.conf`, `http-cache.organisms`), so
+every tick change pays all of it again.
+
+## Finding 1: the static-info load is redundant, not merely oversized
+
+`SingleBlobOrgStrategy.readOrganismsAtTick` reads the tick's BLOB and then loads the entire
+`organisms` table to look up three fields per organism: `parent_id`, `birth_tick`, `genome_hash`.
+
+All three are already in the BLOB it just read — protobuf fields 2, 3 and 28 of `OrganismState` —
+and the table is written from exactly those values (`AbstractH2OrgStorageStrategy.addOrganismMetadataBatch`).
+All three are immutable per organism: parent and birth tick by nature, and the genome hash is
+assigned once, at placement (`SimulationEngine`) or at birth via FORK (`Simulation`), and never
+changed. Table and BLOB therefore always agree, and the existing fallback
+(`staticInfo != null ? staticInfo.parentId : org.getParentId()`) chooses between two identical
+sources.
+
+This is specific to the BLOB strategy. `RowPerOrganismStrategy` solves the same task with a join
+restricted to the tick (`WHERE s.tick_number = ?`) and reads no more than the tick's organisms.
+
+Organisms that died since the last sampled tick are part of the same BLOB — `pruneDeadOrganisms()`
+runs only inside `captureSampledTick`, after serialization — and they carry their static fields like
+any other organism. The set in the BLOB is exactly the set the response needs.
+
+## Finding 2: the whole tree is computed where a closure is needed
+
+The tree has one consumer: lineage colouring in the visualizer. A genome's colour depends only on its
+own ancestor chain — a root hue derived from the genome hash alone, each child hue shifted from its
+parent's. Colours are stable per genome and independent of the rest of the tree. The same colouring
+is applied to the ancestor list in the organism detail view.
+
+What a view needs is therefore the **ancestor closure** of the genomes it displays, not the tree of
+all genomes ever observed. Measured on the published run, that is 719 entries against 150 525 — a
+factor of 209.
+
+The closure cannot be derived from an organism response, and that is not an oversight: an organism
+carries its own genome hash and its parent's *organism id*, but not the parent's genome hash. The
+parent is usually long dead and pruned. The CLI `LineageRenderer` solves the same problem and can
+only do so because it streams every tick from the beginning, accumulating an organism→genome map.
+The visualizer jumps to an arbitrary sampled tick and never streams, so the relation has to be
+served to it.
+
+## Finding 3: the organism total is recomputed although the pipeline delivers it
+
+`readTotalOrganismsCreated` reconstructs the count as `MAX(organism_id) WHERE birth_tick <= ?`.
+The simulation already maintains the value and ships it with every tick — `TickData.total_organisms_created`
+(field 8) and `TickDelta.total_organisms_created` (field 6), documented as *"a monotonic counter that
+includes both initial and child organisms"*. Nothing persists it, so it is derived instead.
+
+`OrganismIndexer.processChunk` currently drops it: the lightweight `TickData` it builds for delta
+ticks copies only the tick number and the organisms.
+
+Its single consumer is the organism panel header, which renders `(alive/total)`.
+
+## Measurements
+
+**Shape of the real data** (run `20260226-03114337`, measured on a reflink copy of the production
+database; the live node was never queried):
+
+| | value |
+|---|---|
+| organisms / genomes / ticks | 14 644 315 / 150 526 / 0 … 2 017 449 974 |
+| genomes with a parent, roots | 150 525 / 304 — no cycles, no self-references, no dangling parents |
+| genome depth to root | min 1, median 19, p90 46, p99 75, **max 89**, mean 24.4 |
+| genomes alive simultaneously | median 397, p90 520, p99 541, **max 548**, mean 372 |
+| ancestor closure for 400 visible genomes | **719 entries** |
+| organism ancestry chain of the youngest organism | 223 |
+
+Simultaneously living genomes come from the `active_genomes` column of `GenomeAnalyticsPlugin`,
+read through the Parquet-backed analyzer API.
+
+**The closure walk over the real data**, after `CREATE INDEX … ON organisms(genome_hash, organism_id)`
+(build: 51–55 s on 14.6 M rows), 400 seed genomes, 719 closure entries, three runs each:
+
+| | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| embedded, genome-wise | 903 ms | **240 ms** | **222 ms** |
+| embedded, level-wise (`IN` list + window function) | 510 ms | 365 ms | 319 ms |
+| over H2 TCP (localhost), genome-wise | 358 ms | **289 ms** | **306 ms** |
+| over H2 TCP (localhost), level-wise | 362 ms | 355 ms | 359 ms |
+
+Both variants return identical results. Without the index, a single walk step costs ~69 ms, which
+extrapolates to ~50 s for the full closure — the index is what makes the approach work at all.
+
+Two caveats: the first run is never truly cold, because the index had just been built; and the file
+did not grow measurably, since MVStore reused free space inside the 33 GB file. For the index size the
+synthetic measurement stands: **+121 MB on a 276 MB `organisms` table** with the same row count.
+
+**Rejected alternatives**, all measured:
+
+| | why not |
+|---|---|
+| materialized `genome_lineage` table (+3 MB, sub-ms lookups) | see below |
+| `INDEX(birth_tick)` for the organism total (+158 MB) | 1 416 ms instead of 5 880 ms — still seconds, for more storage than the genome index |
+| level-wise walk | not faster in either configuration we can run today (table above) |
+
+A materialized genome→parentGenome table was the sketch in #114. It was rejected on architectural
+grounds: maintaining it at index time turns an order-independent function of table content into a
+function of commit order. `AGENTS.md` requires every service except `SimulationEngine` to be capable
+of running as competing consumers, `AbstractBatchIndexer` re-assigns unacknowledged batches after
+`claimTimeout`, and its DLQ path skips a batch entirely. Under any of those, a genome can be recorded
+as a root because the row of its parent organism has not been written yet — and because the first
+writer wins, that error is **permanent**. A read-time derivation has the same exposure while a run is
+still being indexed, but it is **transient**: once the missing rows arrive, the answer corrects
+itself. That difference is the whole argument.
+
+## Solution
+
+### Ancestor closures instead of the full tree
+
+The derivation stays at read time, over the `organisms` table, restricted to the genomes a view
+displays. One step of the walk is today's query for a single genome:
+
+```sql
+SELECT p.genome_hash
+FROM organisms c LEFT JOIN organisms p ON c.parent_id = p.organism_id
+WHERE c.genome_hash = ? AND c.genome_hash <> 0
+  AND (p.genome_hash IS NULL OR p.genome_hash <> c.genome_hash)
+ORDER BY c.organism_id LIMIT 1
+```
+
+A returned parent hash of 0 is normalised to "root", and 0 is never followed. The walk collects every
+genome reachable upwards from the requested ones, driven by a visited set — "already in the result"
+is the termination test — so it terminates on any input.
+
+It is implemented genome-wise, in `H2DatabaseReader`, next to the two `organisms` queries that
+already live there. `IH2OrgStorageStrategy` gains no method: its own contract states that
+`organisms` is not affected by the strategy, three of the four existing queries over that table are
+already inline in the reader, and dispatching only the fourth would give a future strategy no real
+freedom while enlarging the interface.
+
+### The supporting index
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_organisms_genome ON organisms(genome_hash, organism_id)
+```
+
+The DDL is offered as a protected helper on `AbstractH2OrgStorageStrategy` and **called by each
+strategy** from its own `createTables`, next to its own `organisms` DDL — the same shape
+`addOrganismMetadataBatch` already has: the base provides, the strategy decides whether to use it.
+
+`OrganismIndexer.prepareTables` calls `createOrganismTables()` on every start. For a new run the
+table is empty and the index is created instantly. Restarting an indexer on an already populated
+table pays the one-off build — 51 s on 14.6 M rows — inside a blocking DDL, during which competing
+consumers and visualizer readers of `organisms` wait. This is bounded and one-off, but operators
+should know it exists.
+
+The write path pays continuous maintenance for a second secondary index on `organisms`. This is not
+measured. Estimated: organism MERGEs are deduplicated per commit window, so 14.6 M over the whole
+run rather than per tick, against 40 000 BLOB writes totalling over a gigabyte — an overhead in the
+region of 10–20 % of organism indexing, disappearing in the indexer's total throughput.
+
+### The API contract
+
+```java
+// IOrganismDataReader
+- Map<Long, Long> readGenomeLineageTree(long tickNumber);
++ Map<Long, Long> readGenomeAncestors(Collection<Long> genomeHashes);
+```
+
+This is what the controller sees; it never learns which database serves it. The signature takes a
+collection rather than a tick because both callers already hold the data — the tick view has just
+read the organisms, the detail view the ancestry chain. A tick-shaped signature would force the
+implementation to read the tick BLOB a second time and would need a second method for the detail
+view.
+
+Because two implementations must produce identical answers, the contract states the relation itself:
+
+1. **Genome hash 0 is not part of the relation at all.** Such organisms exist — a broken replication
+   loop can produce children without marked molecules — but genome 0 is neither a key nor a parent.
+   A carrier whose parent holds genome 0 is treated exactly like one with no parent.
+2. A genome's parent genome is the genome of the parent organism of its **first carrier**: the lowest
+   `organism_id` among carriers that either have no parent, or whose parent's genome differs from
+   their own. Filtering precedes ordering — a carrier that inherited the genome unchanged is never
+   the first carrier.
+3. A first carrier with no parent, with parent genome 0, or whose parent row is not present makes the
+   genome a **root**. The last case occurs while a run is still being indexed and resolves itself
+   when the missing rows arrive.
+4. The relation is structural: it asks only whether a child's genome differs from its parent's, never
+   why. Mutation and defective replication logic are covered alike, without special handling.
+5. The return value is the closure: every genome reachable upwards from the requested ones, mapped to
+   its parent. A **present key with a `null` value means root**; an **absent key means the genome
+   does not occur in this run**. Every genome that occurs, other than 0, gets an entry.
+6. Implementations accept input collections of arbitrary size and batch internally if their transport
+   makes round trips expensive. Measured for H2: batching is *not* worth it embedded or over
+   localhost TCP; over real network distance it would be.
+
+Three invariants make those rules verifiable, and belong in the same place because a second
+implementer cannot derive them from the code they are writing:
+
+- Organism ids are assigned in creation order (`Simulation.nextOrganismId` only increments, across
+  resume as well), so the lowest id is the earliest carrier.
+- A parent organism is always created before its child, so `parent_id < organism_id`.
+- Therefore the relation is **tick-independent** — the global first carrier of a genome visible at
+  tick T was born no later than T, so it is also the first carrier within any bound `birth_tick <= T`.
+  This is why the old `birth_tick` bound of `readGenomeLineageTree` can be dropped without changing
+  any answer. The existing test `readGenomeLineageTree_respectsBirthTickFilter` is replaced by one
+  asserting that the closure does not depend on the tick requested.
+- And therefore the relation is **acyclic**: if genome A's parent genome were B, then walking up from
+  A's first carrier through parents that still carry B — ids strictly decreasing — reaches a
+  qualifying carrier of B with a lower id than A's. So B's first carrier is older than A's, and the
+  symmetric claim cannot hold at the same time. The visited set is a guard, not a repair.
+
+Point 5 has a technical consequence worth stating in the same place: `null` values rule out
+`Map.of`, `Map.copyOf` and `Collectors.toMap`. The type is unchanged from today's
+`readGenomeLineageTree`, so DTO and frontend keep their shape.
+
+### The organism total
+
+`OrganismIndexer` carries the value into delta ticks:
+
+```java
+TickData deltaAsTick = TickData.newBuilder()
+    .setTickNumber(delta.getTickNumber())
+    .addAllOrganisms(delta.getOrganismsList())
+    .setTotalOrganismsCreated(delta.getTotalOrganismsCreated())   // new
+    .build();
+```
+
+It is stored in a table the shared base owns:
+
+```sql
+CREATE TABLE organism_tick_stats (
+  tick_number             BIGINT PRIMARY KEY,
+  total_organisms_created BIGINT NOT NULL
+)
+```
+
+`StreamingSession` gains a third prepared statement, driven by the base in `commitOrganismWrites`,
+`resetStreamingState` and `purgeClosedConnections` like the two existing ones. A per-strategy layout
+was considered and dropped: the session has to grow either way, a slot used by only one strategy is
+more code in the base rather than less, and the API contract requires both strategies to answer the
+same way — otherwise a configuration choice would change public behaviour. A scalar counter is also
+not organism state; it does not trade storage against query performance in any way the strategy axis
+is about.
+
+An upsert is required rather than an insert: at-least-once delivery means a chunk can be reprocessed.
+Both existing per-tick statements are MERGE for the same reason.
+
+**The stats row is written for every sampled tick, including a tick with no living organisms.** An
+extinction tick is the one tick where "how many were ever created" is the only surviving information.
+The BLOB row stays conditional on a non-empty organism list, so `getAvailableTickRange` is unchanged
+and the visualizer's navigable range does not move.
+
+**A tick with no row raises `TickNotFoundException` instead of returning 0.** Reporting zero organisms
+ever created for a tick that merely was not sampled is a silent wrong answer, indistinguishable from a
+run that genuinely produced nothing. `IH2EnvStorageStrategy.readChunkContaining` already sets this
+precedent on the environment side.
+
+`TickNotFoundException` is a checked exception, so this **is** an API change:
+`IOrganismDataReader.readTotalOrganismsCreated`, `IH2OrgStorageStrategy.readTotalOrganismsCreated`,
+`H2DatabaseReader` and `OrganismController` all declare it. `VisualizerBaseController` already maps it
+to 404. Both JavaDocs are rewritten: the one on `IH2OrgStorageStrategy` currently documents the
+`MAX(organism_id)` derivation *as the contract*, and "or 0 if none exist" is removed from both.
+
+The visualizer does not reach that path in normal operation. `SimulationEngine` initialises its tick
+counter to −1 and increments before sampling, so the first sampled tick is **0**, and 0 is a multiple
+of every interval; sampling is `tick % samplingInterval == 0` on absolute tick numbers, so a resumed
+run stays on the same grid; the metadata endpoint delivers `samplingInterval`; and
+`AppController.navigateToTick` rounds every target down to a multiple of it before clamping to
+`maxTick`. The change becomes visible in two situations, and in both it replaces a silent defect with
+a loud one: a run whose metadata carries no `samplingInterval`, and a hole in the organism data left
+by a DLQ skip. The second matters scientifically — today such a hole renders as an empty population
+over a populated environment, which looks like an extinction event rather than like missing data.
+
+**Widths.** The column is `BIGINT`, matching the wire field, so nothing is narrowed on the write path.
+The API keeps `int`, because the model is bounded at its root: `organism_id` is `INT`, so a run cannot
+exceed 2.1 billion organisms without overflowing the ids themselves. The narrowing happens once, on
+read, and it is not silent — H2 raises error 22003, *"Numeric value out of range"*, rather than
+truncating (verified against 2.4.240). Both facts belong in the JavaDoc so the bound is a stated
+decision rather than an accident.
+
+### HTTP: one response per view
+
+No new endpoint and no new route. The ancestor closure is bundled into the responses that need it:
+
+- `GET /visualizer/api/organisms/{tick}` carries the closure for the genomes of that tick.
+- `GET /visualizer/api/organisms/{tick}/{organismId}` carries the closure for the genomes in the
+  organism's ancestry chain.
+
+Each response is self-contained: no view depends on what another view happened to deliver.
+
+Bundling costs 719 entries — roughly 32 kB against 6.6 MB today — and saves a request, a second
+pooled connection per view, a second read and decompression of the same BLOB, and the entire
+"what do I not know yet" logic in the client. The second connection matters: pool exhaustion is what
+#113 was about.
+
+Both closures are composed **in the controller**, which already holds the reader, the organisms and
+the ancestry chain, and calls `readGenomeAncestors` with the genome hashes it has. Putting the closure
+into `OrganismTickDetails` would instead oblige every database implementation to compute it a second
+time inside `readOrganismDetails`.
+
+The detail view needs its own closure and cannot borrow the tick's: an ancestor organism can carry a
+genome that is not an ancestor *genome* of the displayed one, because a genome hash can arise a second
+time from a different parent genome while the relation records only the first origin. Today the full
+tree covers that case by accident of size. Its cost is small, because the genomes along one organism's
+ancestry chain are nearly collinear — the walk is essentially one chain of at most 89 steps, not 223
+independent ones. The seed set is every genome of the returned chain, not only the five or six the
+frontend displays; that truncation is a display decision and does not belong in the server contract.
+
+`OrganismsResponseDto` replaces `genomeLineageTree` with the closure field, and the detail DTO gains
+the corresponding one.
+
+The ETag `"runId_tick"` does not cover the closure, which is not stable while a run is still being
+indexed. This is unchanged from today, where the same applies to the tree, and HTTP caching for this
+endpoint is disabled by default.
+
+### Frontend
+
+`AppController` **replaces** `_genomeParent` and the colour caches per response, as it does today.
+Merging and keeping them was considered and dropped: on a run that is still being indexed a closure
+can transiently record a genome as a root, and today that error disappears at the next tick change.
+Keeping the caches would make it last the whole session. Recomputing 719 colours costs milliseconds;
+a session-long wrong picture is not worth that saving.
+
+`_computeLineageColor` gains a visited set across its recursion. It currently guards only against a
+genome being its own parent, so a two-node cycle would overflow the stack. That defect predates this
+change and cannot be triggered by the data, but the function is being touched.
+
+Four defensive coercions for fields the new contract guarantees are removed, so a missing field shows
+rather than being replaced by a plausible substitute: `data.totalOrganismCount || 0` and
+`data.genomeLineageTree || {}` in `OrganismApi`, `this.state.totalOrganismCount || organisms.length`
+in `AppController`, and the `if (!tree) return;` guard in `_applyGenomeLineageTree`.
+
+### Runs indexed by older builds
+
+Out of scope. No detection, no migration, no fallback — a database written before this change lacks
+the stored per-tick total, and the organisms endpoint fails for it the way any schema change fails
+today. Making format mismatches explicit is the subject of
+[PERSISTED_FORMAT_VERSIONING](PERSISTED_FORMAT_VERSIONING.md).
+
+### Points checked and deliberately not changed
+
+- `H2DatabaseReader` keeps two further inline `organisms` queries, `readOrganismStaticInfo` and
+  `readLineage`. Moving all queries over that table into one place is a decision about who owns
+  `organisms`, not part of this change.
+- The `organisms` DDL is duplicated in both strategies. Consolidating it would decide, as a side
+  effect, that no future strategy may store static organism metadata differently.
+- `RowPerOrganismStrategy.createTables` ends with `conn.commit()`, `SingleBlobOrgStrategy.createTables`
+  does not. DDL commits implicitly in H2, and both already create the identical `organisms` table
+  across that difference in production.
+- `createTables` is an unenforced convention: a strategy must remember to call the shared helpers and
+  `markTablesCreated()`. Turning it into a template method is a structural change beyond this
+  document.
+
+## Implementation
+
+**Step 1 — Remove the redundant static-info load.** `SingleBlobOrgStrategy.readOrganismsAtTick` takes
+`parent_id`, `birth_tick` and `genome_hash` from the BLOB it already read; `readAllStaticInfo` is
+deleted. Independent of every later step, and the step that removes the heap peak behind #113.
+
+**Step 2 — The organism total.** The indexer carries it into delta ticks; the base creates and writes
+`organism_tick_stats` through a third statement in `StreamingSession`, for every sampled tick;
+`readTotalOrganismsCreated` reads it by primary key and raises `TickNotFoundException` where no row
+exists; the signature change is carried through reader, strategy interface and controller; both
+JavaDocs rewritten.
+
+**Step 3 — The index.** DDL helper on the base, called from each strategy's `createTables`.
+
+**Step 4 — The closure.** `readGenomeAncestors` in `H2DatabaseReader`, walking genome-wise with a
+visited set; `readGenomeLineageTree` removed from reader and `IOrganismDataReader`; the contract and
+its invariants recorded on the new method.
+
+**Step 5 — HTTP.** Both closures composed in the controller and bundled into the tick and detail
+responses; the tree removed from the response DTO.
+
+**Step 6 — Frontend.** Replace instead of merge, visited set in `_computeLineageColor`, the four
+coercions removed.
+
+**Step 7 — Tests.** Small hand-built scenarios:
+
+- first carrier with a differing parent genome → that parent genome is recorded
+- first carrier with no parent → root: key present, value `null`
+- first carrier whose parent carries genome 0 → root as well
+- genome hash 0 as an input produces no entry and no walk
+- a carrier that inherited its genome unchanged is not chosen as the first carrier
+- a carrier whose parent row is absent → root, and the answer corrects itself once the row exists
+- the closure does not depend on the tick requested
+- closure of several genomes with shared ancestors contains each entry exactly once
+- the walk terminates on a hand-built cyclic table
+- the stored total survives a reprocessed chunk
+- a sampled tick without organisms still stores a total
+- a tick with no stats row raises `TickNotFoundException`
+- the tick response no longer carries the full tree
+
+The repository has no test infrastructure for the visualizer's JavaScript, so step 6 carries no
+automated tests. It is verified by hand in step 8, as frontend changes are today.
+
+**Step 8 — Verification on real data.** A copy of the production database is prepared by hand so that
+it looks like one written by the current build — index created, per-tick totals filled in; no backfill
+logic enters the repository — and a throwaway container serves the visualizer from that copy so the
+result can be inspected in the browser. The demo node may be stopped for the duration; it must be
+running unchanged afterwards.

--- a/docs/proposals/GENOME_LINEAGE_INDEXING.md
+++ b/docs/proposals/GENOME_LINEAGE_INDEXING.md
@@ -332,11 +332,16 @@ endpoint is disabled by default.
 
 ### Frontend
 
-`AppController` **replaces** `_genomeParent` and the colour caches per response, as it does today.
-Merging and keeping them was considered and dropped: on a run that is still being indexed a closure
-can transiently record a genome as a root, and today that error disappears at the next tick change.
-Keeping the caches would make it last the whole session. Recomputing 719 colours costs milliseconds;
-a session-long wrong picture is not worth that saving.
+`AppController` clears `_genomeParent` and the colour caches **on every tick change** and adds to
+them within one tick. Keeping them across tick changes was considered and dropped: on a run that is
+still being indexed a closure can transiently record a genome as a root, and today that error
+disappears at the next tick change. Keeping the caches would make it last the whole session.
+Recomputing 719 colours costs milliseconds; a session-long wrong picture is not worth that saving.
+
+Adding within one tick is required because a view is served by two responses — the organisms of the
+tick and, when one is selected, its ancestry chain, whose ancestors need not appear at that tick.
+Their closures overlap but neither contains the other. Both come from the same relation, so a genome
+present in both carries the same parent and adding cannot contradict what is already there.
 
 `_computeLineageColor` gains a visited set across its recursion. It currently guards only against a
 genome being its own parent, so a two-node cycle would overflow the stack. That defect predates this
@@ -411,8 +416,20 @@ coercions removed.
 The repository has no test infrastructure for the visualizer's JavaScript, so step 6 carries no
 automated tests. It is verified by hand in step 8, as frontend changes are today.
 
-**Step 8 — Verification on real data.** A copy of the production database is prepared by hand so that
-it looks like one written by the current build — index created, per-tick totals filled in; no backfill
-logic enters the repository — and a throwaway container serves the visualizer from that copy so the
-result can be inspected in the browser. The demo node may be stopped for the duration; it must be
-running unchanged afterwards.
+**Step 8 — Verification in the browser.** On a run produced by the current build.
+
+The published run cannot serve this purpose, and the reason is worth recording. Its organism blobs
+were written in February 2026, before commit `8919f646` renumbered the fields of `OrganismState`;
+a current build fails to parse them with *"Protocol message had invalid UTF-8"*, which is the exact
+consequence [PERSISTED_FORMAT_VERSIONING](PERSISTED_FORMAT_VERSIONING.md) records as evidence. The
+demo node serves that run only because its image predates the renumbering. This is independent of
+this change and blocks any browser check against existing data.
+
+The read paths this change touches were therefore verified against the production data directly,
+which needs no blob parsing:
+
+- the static fields of 4 604 organisms across seven ticks spanning the whole run agree between blob
+  and table without exception;
+- the stored organism total agrees with the derived one at six ticks across six orders of magnitude;
+- and the ancestor relation, seeded with **all 150 525 genomes of the run**, agrees with the old
+  full-tree query entry for entry, in both directions — in 5.8 s against the old query's 10.7 s.

--- a/docs/proposals/GENOME_LINEAGE_INDEXING.md
+++ b/docs/proposals/GENOME_LINEAGE_INDEXING.md
@@ -347,10 +347,11 @@ present in both carries the same parent and adding cannot contradict what is alr
 genome being its own parent, so a two-node cycle would overflow the stack. That defect predates this
 change and cannot be triggered by the data, but the function is being touched.
 
-Four defensive coercions for fields the new contract guarantees are removed, so a missing field shows
-rather than being replaced by a plausible substitute: `data.totalOrganismCount || 0` and
-`data.genomeLineageTree || {}` in `OrganismApi`, `this.state.totalOrganismCount || organisms.length`
-in `AppController`, and the `if (!tree) return;` guard in `_applyGenomeLineageTree`.
+Five defensive coercions for fields the new contract guarantees are removed, so a missing field shows
+rather than being replaced by a plausible substitute: `Array.isArray(data.organisms) ? … : []`,
+`data.totalOrganismCount || 0` and `data.genomeLineageTree || {}` in `OrganismApi`,
+`this.state.totalOrganismCount || organisms.length` in `AppController`, and the `if (!tree) return;`
+guard in `_applyGenomeLineageTree`.
 
 ### Runs indexed by older builds
 

--- a/docs/proposals/GENOME_LINEAGE_INDEXING.md
+++ b/docs/proposals/GENOME_LINEAGE_INDEXING.md
@@ -307,8 +307,8 @@ Each response is self-contained: no view depends on what another view happened t
 
 Bundling costs 719 entries — roughly 32 kB against 6.6 MB today — and saves a request, a second
 pooled connection per view, a second read and decompression of the same BLOB, and the entire
-"what do I not know yet" logic in the client. The second connection matters: pool exhaustion is what
-#113 was about.
+"what do I not know yet" logic in the client. The second connection matters: pool exhaustion is
+what #113 was about.
 
 Both closures are composed **in the controller**, which already holds the reader, the organisms and
 the ancestry chain, and calls `readGenomeAncestors` with the genome hashes it has. Putting the closure

--- a/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
@@ -4,6 +4,7 @@ import org.evochora.datapipeline.api.resources.database.dto.OrganismTickDetails;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -52,16 +53,46 @@ public interface IOrganismDataReader {
     int readTotalOrganismsCreated(long tickNumber) throws SQLException, TickNotFoundException;
 
     /**
-     * Reads the genome lineage tree: a mapping of each genome hash to its parent genome hash.
+     * Reads the ancestor closure of the given genomes: every genome reachable upwards from them,
+     * mapped to its parent genome.
      * <p>
-     * Returns all distinct genome→parentGenome pairs for organisms born up to the given tick.
-     * Root genomes (no parent or parent has genomeHash 0) map to {@code null}.
+     * <strong>What a parent genome is.</strong> A genome's parent genome is the genome of the
+     * parent organism of that genome's <em>first carrier</em> — the carrier with the lowest
+     * organism id among those that either have no parent, or whose parent carries a different
+     * genome. Filtering precedes ordering: a carrier that inherited its genome unchanged is never
+     * the first carrier, so a genome never becomes its own ancestor.
+     * <p>
+     * A first carrier with no parent, or whose parent carries genome hash 0, makes the genome a
+     * root. So does a parent whose organism is not indexed, which happens while a run is still
+     * being indexed and resolves itself once the missing rows arrive.
+     * <p>
+     * Genome hash 0 is not part of the relation. Organisms carrying it exist — a defective
+     * replication loop can produce children without marked molecules — but 0 is neither a key nor
+     * a parent, and requesting it yields nothing.
+     * <p>
+     * The relation is structural: it asks only whether a child's genome differs from its parent's,
+     * never why. Mutation and defective replication are covered alike.
+     * <p>
+     * <strong>What the result means.</strong> A key present with a {@code null} value is a root.
+     * An absent key means the genome does not occur in this run; every genome that does occur, other
+     * than 0, has an entry. Callers depend on that distinction, so the returned map must permit null
+     * values — {@code Map.of}, {@code Map.copyOf} and {@code Collectors.toMap} cannot be used to
+     * build it.
+     * <p>
+     * <strong>Invariants an implementation may rely on.</strong> Organism ids are assigned in
+     * creation order and a parent is always created before its child, so the lowest id is the
+     * earliest carrier. It follows that the relation does not depend on any tick: the first carrier
+     * of a genome visible at a tick was born no later than that tick. It also follows that the
+     * relation is acyclic, since walking upwards strictly decreases the id of the first carrier.
+     * <p>
+     * Input collections of any size are accepted; an implementation whose query language limits
+     * parameters batches internally rather than asking callers to split their request.
      *
-     * @param tickNumber Upper bound for organism birth tick (inclusive).
-     * @return Map of genomeHash → parentGenomeHash (null for roots). Never null.
+     * @param genomeHashes Genomes to start from. May contain duplicates and genome hash 0.
+     * @return Map of genomeHash → parentGenomeHash, null value for roots. Never null.
      * @throws SQLException if database read fails.
      */
-    Map<Long, Long> readGenomeLineageTree(long tickNumber) throws SQLException;
+    Map<Long, Long> readGenomeAncestors(Collection<Long> genomeHashes) throws SQLException;
 }
 
 

--- a/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
@@ -35,12 +35,21 @@ public interface IOrganismDataReader {
 
     /**
      * Reads the total number of organisms created up to (and including) the given tick.
+     * <p>
+     * This is the value the simulation reported for that tick, not a value derived from organism
+     * ids. A tick for which no data was indexed has no such value.
+     * <p>
+     * The result is an {@code int} because the model is bounded at its root: organism ids are
+     * {@code INT}, so a run cannot exceed that many organisms without overflowing the ids
+     * themselves. An implementation must fail rather than truncate if the stored value exceeds
+     * that range.
      *
-     * @param tickNumber Tick number (inclusive upper bound).
-     * @return Total organisms created by this tick, or 0 if none exist.
+     * @param tickNumber Tick number.
+     * @return Total organisms created by this tick.
      * @throws SQLException if database read fails.
+     * @throws TickNotFoundException if no data is indexed for the given tick.
      */
-    int readTotalOrganismsCreated(long tickNumber) throws SQLException;
+    int readTotalOrganismsCreated(long tickNumber) throws SQLException, TickNotFoundException;
 
     /**
      * Reads the genome lineage tree: a mapping of each genome hash to its parent genome hash.

--- a/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
+++ b/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
@@ -71,11 +71,13 @@ public abstract class AbstractResource implements IResource, IMonitorable {
     /**
      * Records an operational error for tracking and monitoring.
      * <p>
-     * <strong>IMPORTANT:</strong> Use this method ONLY for transient errors where the resource
-     * continues functioning. For fatal errors that prevent operation, log and throw an exception instead.
+     * <strong>IMPORTANT:</strong> Whether an error is recorded is independent of whether it is
+     * thrown. Recording reflects the state of the resource; throwing reports the outcome of a
+     * single operation to its caller. A resource that must tell its caller about a failure still
+     * records that failure.
      * <p>
-     * Use this method to track transient errors that don't prevent the resource from functioning
-     * but may indicate problems. These errors affect the resource's health status ({@link #isHealthy()}).
+     * Use this method to track errors that indicate problems with the resource, whether or not it
+     * keeps functioning. These errors affect the resource's health status ({@link #isHealthy()}).
      * <p>
      * The error collection is bounded by {@link #getMaxErrors()} to prevent unbounded
      * memory growth. When the limit is exceeded, the oldest errors are automatically removed.
@@ -90,11 +92,13 @@ public abstract class AbstractResource implements IResource, IMonitorable {
      *   <li>Example: SQL constraint violation, dropped DLQ message, temporary connection issue</li>
      * </ul>
      * 
-     * <strong>2. Fatal Errors</strong> (resource cannot continue):
+     * <strong>2. Fatal Errors</strong> (resource cannot serve any caller):
      * <ul>
      *   <li>Use: {@code log.error("message with context", args)} - NO exception parameter</li>
-     *   <li>Do NOT use recordError() - resource is broken anyway</li>
-     *   <li>Throw exception - caller handles it</li>
+     *   <li>Use: {@link #recordError(String, String, String)} - a resource does not stop itself,
+     *       so an unusable resource reports {@link org.evochora.datapipeline.api.resources.IResource.UsageState#FAILED}
+     *       only if the error is recorded</li>
+     *   <li>Throw exception - caller handles the failed operation</li>
      *   <li>Example: Cannot initialize connection pool, schema creation failed, storage not accessible</li>
      * </ul>
      * 

--- a/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
+++ b/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
@@ -117,8 +117,10 @@ public abstract class AbstractResource implements IResource, IMonitorable {
      *   <li>Example: {@code catch(IOException e) { log.debug("Retry {}/{}", attempt, max); }}</li>
      * </ul>
      * 
-     * <strong>Stack Traces:</strong> Exception stack traces should be logged at DEBUG level
-     * separately if needed. Resources should never log exceptions with {@code log.error(..., e)}.
+     * <strong>Stack Traces:</strong> Pass the exception to {@code log.error(..., e)} only for bugs
+     * and for system faults whose cause lies outside the application, where the chained causes are
+     * the diagnosis. For expected errors the message already states the cause, and the stack trace
+     * is omitted.
      *
      * @param code    Error code for categorization (e.g., "CONNECTION_FAILED", "READ_ERROR")
      * @param message Human-readable error message

--- a/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
+++ b/src/main/java/org/evochora/datapipeline/resources/AbstractResource.java
@@ -25,8 +25,8 @@ public abstract class AbstractResource implements IResource, IMonitorable {
     
     /**
      * Collection of operational errors that occurred during resource operations.
-     * These are transient errors that don't prevent the resource from functioning
-     * but may indicate problems.
+     * These are transient errors the resource kept working through, and fatal ones that leave it
+     * unable to serve any caller - a resource does not stop itself, so both belong here.
      * <p>
      * Private to enforce use of {@link #recordError(String, String, String)} method.
      * Subclasses must not access this directly - use protected methods like
@@ -94,7 +94,9 @@ public abstract class AbstractResource implements IResource, IMonitorable {
      * 
      * <strong>2. Fatal Errors</strong> (resource cannot serve any caller):
      * <ul>
-     *   <li>Use: {@code log.error("message with context", args)} - NO exception parameter</li>
+     *   <li>Use: {@code log.error("message with context", args)} - without the exception for an
+     *       expected failure, with it when the cause lies outside the application and the chained
+     *       causes are the diagnosis (see <strong>Stack Traces</strong> below)</li>
      *   <li>Use: {@link #recordError(String, String, String)} - a resource does not stop itself,
      *       so an unusable resource reports {@link org.evochora.datapipeline.api.resources.IResource.UsageState#FAILED}
      *       only if the error is recorded</li>

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2Database.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2Database.java
@@ -792,21 +792,6 @@ public class H2Database extends AbstractDatabaseResource
         metrics.put("jvm_daemon_thread_count", threads.getDaemonThreadCount());
         metrics.put("jvm_peak_thread_count", threads.getPeakThreadCount());
         
-        if (dataSource != null && !dataSource.isClosed()) {
-            // H2 cache size (fast query in INFORMATION_SCHEMA, acceptable during metrics read)
-            try (Connection conn = dataSource.getConnection();
-                 Statement stmt = conn.createStatement();
-                 ResultSet rs = stmt.executeQuery(
-                     "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME = 'info.CACHE_SIZE'")) {
-                
-                if (rs.next()) {
-                    metrics.put("h2_cache_size_bytes", rs.getLong("VALUE"));
-                }
-            } catch (SQLException e) {
-                // Log but don't fail metrics collection
-                log.debug("Failed to query H2 cache size: {}", e.getMessage());
-            }
-        }
     }
 
     /**
@@ -919,6 +904,10 @@ public class H2Database extends AbstractDatabaseResource
      * Recording the failure is what turns that into a visible
      * {@link org.evochora.datapipeline.api.resources.IResource.UsageState#FAILED} state;
      * the exception itself only informs the caller of the current operation.
+     * <p>
+     * The exception is logged with its stack trace because this is a system fault: HikariCP
+     * chains the underlying failure that prevented connection creation, and that chain is the
+     * only place where the actual cause appears.
      *
      * @param context Description of the operation requesting the connection, for error details.
      * @return A pooled connection that the caller must close.
@@ -929,7 +918,7 @@ public class H2Database extends AbstractDatabaseResource
             return dataSource.getConnection();
         } catch (SQLException e) {
             log.error("H2 database '{}' cannot acquire a connection for {}: {}",
-                getResourceName(), context, e.getMessage());
+                getResourceName(), context, e.getMessage(), e);
             recordError("CONNECTION_ACQUIRE_FAILED", "Cannot acquire a database connection",
                 "Database: " + getResourceName() + ", Context: " + context + ", Error: " + e.getMessage());
             throw e;

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2Database.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2Database.java
@@ -339,7 +339,7 @@ public class H2Database extends AbstractDatabaseResource
 
     @Override
     protected Object acquireDedicatedConnection() throws Exception {
-        Connection conn = dataSource.getConnection();
+        Connection conn = acquireConnection("dedicated wrapper connection");
         conn.setAutoCommit(false);
         return conn;
     }
@@ -913,6 +913,30 @@ public class H2Database extends AbstractDatabaseResource
     }
     
     /**
+     * Acquires a pooled connection and reports a failed acquisition as a resource error.
+     * <p>
+     * A pool that cannot hand out a connection makes the database unusable for every caller.
+     * Recording the failure is what turns that into a visible
+     * {@link org.evochora.datapipeline.api.resources.IResource.UsageState#FAILED} state;
+     * the exception itself only informs the caller of the current operation.
+     *
+     * @param context Description of the operation requesting the connection, for error details.
+     * @return A pooled connection that the caller must close.
+     * @throws SQLException if no connection can be acquired.
+     */
+    private Connection acquireConnection(String context) throws SQLException {
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException e) {
+            log.error("H2 database '{}' cannot acquire a connection for {}: {}",
+                getResourceName(), context, e.getMessage());
+            recordError("CONNECTION_ACQUIRE_FAILED", "Cannot acquire a database connection",
+                "Database: " + getResourceName() + ", Context: " + context + ", Error: " + e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
      * Creates a new {@link IDatabaseReader} bound to the given run ID's schema.
      * <p>
      * Acquires a pooled connection from HikariCP, sets the H2 schema to the run ID
@@ -940,7 +964,7 @@ public class H2Database extends AbstractDatabaseResource
         // Check for stale reader connections before acquiring a new one
         warnStaleReaderConnections();
 
-        Connection conn = dataSource.getConnection();
+        Connection conn = acquireConnection("createReader(" + runId + ")");
         boolean success = false;
         try {
             H2SchemaUtil.setSchema(conn, runId);
@@ -1006,7 +1030,7 @@ public class H2Database extends AbstractDatabaseResource
 
     @Override
     public String findLatestRunId() throws SQLException {
-        try (Connection conn = dataSource.getConnection()) {
+        try (Connection conn = acquireConnection("findLatestRunId")) {
             // Step 1: Find latest simulation schema
             String latestSchema;
             try (Statement stmt = conn.createStatement();

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
@@ -193,8 +193,10 @@ public class H2DatabaseReader implements IDatabaseReader {
                 try (ResultSet rs = stmt.executeQuery()) {
                     occurs = rs.next();
                     if (occurs) {
+                        // A parent carrying genome 0 passes the query's filter and becomes a
+                        // root here; a parent carrying the same genome is already excluded there.
                         long parent = rs.getLong("parent_genome_hash");
-                        if (!rs.wasNull() && parent != 0L && parent != genomeHash) {
+                        if (!rs.wasNull() && parent != 0L) {
                             parentGenomeHash = parent;
                         }
                     }

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
@@ -139,7 +139,7 @@ public class H2DatabaseReader implements IDatabaseReader {
     }
 
     @Override
-    public int readTotalOrganismsCreated(long tickNumber) throws SQLException {
+    public int readTotalOrganismsCreated(long tickNumber) throws SQLException, TickNotFoundException {
         ensureNotClosed();
         return orgStrategy.readTotalOrganismsCreated(connection, tickNumber);
     }

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
@@ -4,7 +4,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,40 +150,64 @@ public class H2DatabaseReader implements IDatabaseReader {
     /**
      * {@inheritDoc}
      * <p>
-     * Queries the {@code organisms} static table directly (strategy-independent).
-     * Self-referencing rows (child genome equals parent genome, i.e. no mutation) are excluded
-     * by the SQL filter. When multiple organisms share the same genome hash, the first by
-     * {@code organism_id} determines the parent mapping.
+     * Queries the {@code organisms} static table directly, one step of the walk per statement.
+     * The step selects the lowest-id carrier of a genome whose parent carries a different genome,
+     * which the {@code (genome_hash, organism_id)} index turns into a seek.
+     * <p>
+     * The walk is driven by the result map itself: a genome already present is not visited again,
+     * so it terminates on any input.
      * <p>
      * Not thread-safe — each {@link H2DatabaseReader} instance holds a dedicated connection
      * and must not be shared across threads.
      */
     @Override
-    public Map<Long, Long> readGenomeLineageTree(long tickNumber) throws SQLException {
+    public Map<Long, Long> readGenomeAncestors(Collection<Long> genomeHashes) throws SQLException {
         ensureNotClosed();
 
         String sql = """
-            SELECT c.genome_hash, p.genome_hash AS parent_genome_hash
+            SELECT p.genome_hash AS parent_genome_hash
             FROM organisms c
             LEFT JOIN organisms p ON c.parent_id = p.organism_id
-            WHERE c.birth_tick <= ? AND c.genome_hash != 0
-              AND (p.genome_hash IS NULL OR c.genome_hash != p.genome_hash)
+            WHERE c.genome_hash = ? AND c.genome_hash != 0
+              AND (p.genome_hash IS NULL OR p.genome_hash != c.genome_hash)
             ORDER BY c.organism_id
+            LIMIT 1
             """;
 
-        Map<Long, Long> tree = new LinkedHashMap<>();
+        Map<Long, Long> ancestors = new LinkedHashMap<>();
+        Deque<Long> pending = new ArrayDeque<>();
+        for (Long genomeHash : genomeHashes) {
+            if (genomeHash != null && genomeHash != 0L) {
+                pending.add(genomeHash);
+            }
+        }
+
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setLong(1, tickNumber);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    long genomeHash = rs.getLong("genome_hash");
-                    if (tree.containsKey(genomeHash)) continue;
-                    long parentGenomeHash = rs.getLong("parent_genome_hash");
-                    tree.put(genomeHash, (rs.wasNull() || parentGenomeHash == 0) ? null : parentGenomeHash);
+            while (!pending.isEmpty()) {
+                long genomeHash = pending.poll();
+                if (ancestors.containsKey(genomeHash)) continue;
+
+                stmt.setLong(1, genomeHash);
+                Long parentGenomeHash = null;
+                boolean occurs;
+                try (ResultSet rs = stmt.executeQuery()) {
+                    occurs = rs.next();
+                    if (occurs) {
+                        long parent = rs.getLong("parent_genome_hash");
+                        if (!rs.wasNull() && parent != 0L && parent != genomeHash) {
+                            parentGenomeHash = parent;
+                        }
+                    }
+                }
+                if (!occurs) continue;   // genome does not occur in this run: no entry
+
+                ancestors.put(genomeHash, parentGenomeHash);
+                if (parentGenomeHash != null && !ancestors.containsKey(parentGenomeHash)) {
+                    pending.add(parentGenomeHash);
                 }
             }
         }
-        return tree;
+        return ancestors;
     }
 
     @Override

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/AbstractH2OrgStorageStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/AbstractH2OrgStorageStrategy.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -11,6 +12,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.evochora.datapipeline.api.contracts.OrganismState;
 import org.evochora.datapipeline.api.contracts.TickData;
+import org.evochora.datapipeline.api.resources.database.TickNotFoundException;
+import org.evochora.datapipeline.utils.H2SchemaUtil;
 import org.evochora.datapipeline.utils.compression.CompressionCodecFactory;
 import org.evochora.datapipeline.utils.compression.ICompressionCodec;
 import org.slf4j.Logger;
@@ -89,8 +92,14 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
     protected record StreamingSession(
             PreparedStatement organismsStmt,
             PreparedStatement statesStmt,
+            PreparedStatement tickStatsStmt,
             Set<Integer> seenOrganisms
     ) {}
+
+    /** SQL for the per-tick statistics shared by all organism storage strategies. */
+    private static final String TICK_STATS_MERGE_SQL =
+            "MERGE INTO organism_tick_stats (tick_number, total_organisms_created) "
+            + "KEY (tick_number) VALUES (?, ?)";
 
     /** Per-connection sessions (thread-safe for competing consumers sharing this strategy instance). */
     private final ConcurrentHashMap<Connection, StreamingSession> sessions = new ConcurrentHashMap<>();
@@ -135,6 +144,7 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
                     return new StreamingSession(
                             c.prepareStatement(getStreamOrganismsMergeSql()),
                             c.prepareStatement(getStreamStatesMergeSql()),
+                            c.prepareStatement(TICK_STATS_MERGE_SQL),
                             new HashSet<>()
                     );
                 } catch (SQLException e) {
@@ -187,10 +197,48 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
     }
 
     /**
+     * Creates the per-tick statistics table shared by all organism storage strategies.
+     * <p>
+     * Holds the running organism total the simulation reports with every tick. Strategies call
+     * this from their own {@link #createTables(Connection)}; a strategy that does not use the
+     * shared static organism data does not call it and does not get the table.
+     *
+     * @param stmt Statement on a connection with the run schema already set
+     * @throws SQLException if the DDL fails for a reason other than the object already existing
+     */
+    protected void createTickStatsTable(Statement stmt) throws SQLException {
+        H2SchemaUtil.executeDdlIfNotExists(
+            stmt,
+            "CREATE TABLE IF NOT EXISTS organism_tick_stats (" +
+            "  tick_number BIGINT PRIMARY KEY," +
+            "  total_organisms_created BIGINT NOT NULL" +
+            ")",
+            "organism_tick_stats"
+        );
+    }
+
+    /**
+     * Adds the per-tick statistics of one tick to the batch.
+     * <p>
+     * Called once per tick, including ticks whose organism list is empty: an extinction tick is
+     * the one tick where the number of organisms ever created is the only surviving information.
+     *
+     * @param session The streaming session for the current connection
+     * @param tick Tick data carrying the tick number and the running organism total
+     * @throws SQLException if parameter setting or addBatch fails
+     */
+    protected void addTickStatsBatch(StreamingSession session, TickData tick) throws SQLException {
+        PreparedStatement stmt = session.tickStatsStmt();
+        stmt.setLong(1, tick.getTickNumber());
+        stmt.setLong(2, tick.getTotalOrganismsCreated());
+        stmt.addBatch();
+    }
+
+    /**
      * {@inheritDoc}
      * <p>
-     * Executes organism metadata and state batches, then clears the deduplication set.
-     * Statements remain open for reuse in the next commit window.
+     * Executes organism metadata, state and per-tick statistics batches, then clears the
+     * deduplication set. Statements remain open for reuse in the next commit window.
      */
     @Override
     public void commitOrganismWrites(Connection conn) throws SQLException {
@@ -203,6 +251,7 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
             session.organismsStmt().executeBatch();
         }
         session.statesStmt().executeBatch();
+        session.tickStatsStmt().executeBatch();
 
         // Reset per-commit state; statements stay open for reuse
         session.seenOrganisms().clear();
@@ -221,6 +270,7 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
         if (session != null) {
             closeQuietly(session.organismsStmt());
             closeQuietly(session.statesStmt());
+            closeQuietly(session.tickStatsStmt());
         }
     }
 
@@ -242,11 +292,13 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
                 if (c.isClosed()) {
                     closeQuietly(entry.getValue().organismsStmt());
                     closeQuietly(entry.getValue().statesStmt());
+                    closeQuietly(entry.getValue().tickStatsStmt());
                     return true;
                 }
             } catch (SQLException e) {
                 closeQuietly(entry.getValue().organismsStmt());
                 closeQuietly(entry.getValue().statesStmt());
+                closeQuietly(entry.getValue().tickStatsStmt());
                 return true;
             }
             return false;
@@ -270,12 +322,16 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
     }
 
     @Override
-    public int readTotalOrganismsCreated(Connection conn, long tickNumber) throws SQLException {
-        String sql = "SELECT MAX(organism_id) FROM organisms WHERE birth_tick <= ?";
+    public int readTotalOrganismsCreated(Connection conn, long tickNumber)
+            throws SQLException, TickNotFoundException {
+        String sql = "SELECT total_organisms_created FROM organism_tick_stats WHERE tick_number = ?";
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setLong(1, tickNumber);
             try (ResultSet rs = stmt.executeQuery()) {
-                return rs.next() ? rs.getInt(1) : 0;
+                if (!rs.next()) {
+                    throw new TickNotFoundException("No organism tick statistics for tick " + tickNumber);
+                }
+                return rs.getInt(1);
             }
         }
     }

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/AbstractH2OrgStorageStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/AbstractH2OrgStorageStrategy.java
@@ -218,6 +218,28 @@ public abstract class AbstractH2OrgStorageStrategy implements IH2OrgStorageStrat
     }
 
     /**
+     * Creates the index that makes an ancestor walk over the static organism data affordable.
+     * <p>
+     * Resolving one genome's parent genome selects the lowest-id carrier of that genome. Without
+     * this index every step of the walk is a full table scan; with it, a step is a seek. The index
+     * is offered here rather than imposed: a strategy that lays out the static organism data
+     * differently does not call this and provides its own answer.
+     * <p>
+     * On an already populated table the build is a one-off blocking operation. It is instant for a
+     * new run, where the table is still empty when the strategy creates its schema.
+     *
+     * @param stmt Statement on a connection with the run schema already set
+     * @throws SQLException if the DDL fails for a reason other than the object already existing
+     */
+    protected void createGenomeIndex(Statement stmt) throws SQLException {
+        H2SchemaUtil.executeDdlIfNotExists(
+            stmt,
+            "CREATE INDEX IF NOT EXISTS idx_organisms_genome ON organisms (genome_hash, organism_id)",
+            "idx_organisms_genome"
+        );
+    }
+
+    /**
      * Adds the per-tick statistics of one tick to the batch.
      * <p>
      * Called once per tick, including ticks whose organism list is empty: an extinction tick is

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/IH2OrgStorageStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/IH2OrgStorageStrategy.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.evochora.datapipeline.api.contracts.TickData;
+import org.evochora.datapipeline.api.resources.database.TickNotFoundException;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
 import org.evochora.datapipeline.api.resources.database.dto.TickRange;
 
@@ -126,15 +127,18 @@ public interface IH2OrgStorageStrategy {
     /**
      * Reads the total number of organisms created up to (and including) the given tick.
      * <p>
-     * Uses the sequential nature of organism IDs: MAX(organism_id) WHERE birth_tick &lt;= tickNumber
-     * equals the total count of organisms ever created by that tick.
+     * Returns the value the simulation reported for that tick, stored when the tick was indexed.
+     * A tick that was never sampled has no such value; reporting zero for it would be
+     * indistinguishable from a run that produced no organisms at all.
      *
      * @param conn Database connection (schema already set)
-     * @param tickNumber Tick number (inclusive upper bound for birth_tick)
-     * @return Total organisms created, or 0 if no organisms exist
+     * @param tickNumber Tick number
+     * @return Total organisms created by that tick
      * @throws SQLException if database read fails
+     * @throws TickNotFoundException if no statistics are stored for the given tick
      */
-    int readTotalOrganismsCreated(Connection conn, long tickNumber) throws SQLException;
+    int readTotalOrganismsCreated(Connection conn, long tickNumber)
+            throws SQLException, TickNotFoundException;
 
     /**
      * Reads a single organism's state at the given tick.

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategy.java
@@ -132,6 +132,8 @@ public class RowPerOrganismStrategy extends AbstractH2OrgStorageStrategy {
                     "CREATE INDEX IF NOT EXISTS idx_organism_states_org ON organism_states (organism_id)",
                     "idx_organism_states_org"
             );
+
+            createTickStatsTable(stmt);
         }
 
         conn.commit();
@@ -164,6 +166,7 @@ public class RowPerOrganismStrategy extends AbstractH2OrgStorageStrategy {
     public void addOrganismTick(Connection conn, TickData tick) throws SQLException {
         StreamingSession session = ensureStreamingSession(conn);
         addOrganismMetadataBatch(session, tick);
+        addTickStatsBatch(session, tick);
 
         // Per-tick organism states (one row per organism)
         PreparedStatement statesStmt = session.statesStmt();

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategy.java
@@ -134,6 +134,7 @@ public class RowPerOrganismStrategy extends AbstractH2OrgStorageStrategy {
             );
 
             createTickStatsTable(stmt);
+            createGenomeIndex(stmt);
         }
 
         conn.commit();

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
@@ -96,6 +96,7 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
             );
 
             createTickStatsTable(stmt);
+            createGenomeIndex(stmt);
         }
 
         markTablesCreated();

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
@@ -166,19 +166,15 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
             return new ArrayList<>();
         }
         
-        // 2. Read static info from organisms table (for parent_id, birth_tick)
-        java.util.Map<Integer, StaticInfo> staticInfoMap = readAllStaticInfo(conn);
-        
-        // 3. Convert to DTOs
+        // 2. Convert to DTOs. parent_id, birth_tick and genome_hash are immutable per organism
+        //    and are carried by the serialized state itself, so the organisms table is not read.
         List<OrganismTickSummary> result = new ArrayList<>(organisms.size());
         for (OrganismState org : organisms) {
             int organismId = org.getOrganismId();
-            StaticInfo staticInfo = staticInfoMap.get(organismId);
-            
-            Integer parentId = staticInfo != null ? staticInfo.parentId :
-                    (org.hasParentId() ? org.getParentId() : null);
-            long birthTick = staticInfo != null ? staticInfo.birthTick : org.getBirthTick();
-            long genomeHash = staticInfo != null ? staticInfo.genomeHash : org.getGenomeHash();
+
+            Integer parentId = org.hasParentId() ? org.getParentId() : null;
+            long birthTick = org.getBirthTick();
+            long genomeHash = org.getGenomeHash();
 
             result.add(new OrganismTickSummary(
                 organismId,
@@ -278,35 +274,6 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
         }
     }
     
-    /**
-     * Reads static organism info (parent_id, birth_tick, genome_hash) for all organisms.
-     */
-    private java.util.Map<Integer, StaticInfo> readAllStaticInfo(Connection conn) throws SQLException {
-        String sql = "SELECT organism_id, parent_id, birth_tick, genome_hash FROM organisms";
-
-        java.util.Map<Integer, StaticInfo> result = new java.util.HashMap<>();
-
-        try (PreparedStatement stmt = conn.prepareStatement(sql);
-             ResultSet rs = stmt.executeQuery()) {
-
-            while (rs.next()) {
-                int organismId = rs.getInt("organism_id");
-                int parentIdRaw = rs.getInt("parent_id");
-                Integer parentId = rs.wasNull() ? null : parentIdRaw;
-                long birthTick = rs.getLong("birth_tick");
-                long genomeHash = rs.getLong("genome_hash");
-
-                result.put(organismId, new StaticInfo(parentId, birthTick, genomeHash));
-            }
-        }
-
-        return result;
-    }
-    
-    /**
-     * Helper record for static organism info.
-     */
-    private record StaticInfo(Integer parentId, long birthTick, long genomeHash) {}
     
     /**
      * Converts a Protobuf Vector to int[].

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
@@ -277,8 +277,7 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
             }
         }
     }
-    
-    
+
     /**
      * Converts a Protobuf Vector to int[].
      */

--- a/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategy.java
@@ -94,6 +94,8 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
                 ")",
                 "organism_ticks"
             );
+
+            createTickStatsTable(stmt);
         }
 
         markTablesCreated();
@@ -125,6 +127,7 @@ public class SingleBlobOrgStrategy extends AbstractH2OrgStorageStrategy {
     public void addOrganismTick(Connection conn, TickData tick) throws SQLException {
         StreamingSession session = ensureStreamingSession(conn);
         addOrganismMetadataBatch(session, tick);
+        addTickStatsBatch(session, tick);
 
         // Per-tick BLOB (all organisms serialized + compressed)
         if (!tick.getOrganismsList().isEmpty()) {

--- a/src/main/java/org/evochora/datapipeline/services/indexers/OrganismIndexer.java
+++ b/src/main/java/org/evochora/datapipeline/services/indexers/OrganismIndexer.java
@@ -105,11 +105,13 @@ public class OrganismIndexer<ACK> extends AbstractBatchIndexer<ACK> implements I
         // Snapshot tick
         database.writeOrganismTick(chunk.getSnapshot());
 
-        // Delta ticks (converted to TickData — database only needs tickNumber + organisms)
+        // Delta ticks (converted to TickData — the database needs the tick number, the organisms
+        // and the running organism total, which it stores per tick rather than deriving it)
         for (TickDelta delta : chunk.getDeltasList()) {
             TickData deltaAsTick = TickData.newBuilder()
                 .setTickNumber(delta.getTickNumber())
                 .addAllOrganisms(delta.getOrganismsList())
+                .setTotalOrganismsCreated(delta.getTotalOrganismsCreated())
                 .build();
             database.writeOrganismTick(deltaAsTick);
         }

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
@@ -86,9 +86,9 @@ public class OrganismController extends VisualizerBaseController {
      * Response format:
      * <pre>
      * {
-     *   "runId": "string",
-     *   "tick": 1234,
-     *   "organisms": [ OrganismTickSummary... ]
+     *   "organisms": [ OrganismTickSummary... ],
+     *   "totalOrganismCount": 4711,
+     *   "genomeAncestors": { "genomeHash": "parentGenomeHash or null", ... }
      * }
      * </pre>
      *
@@ -161,11 +161,11 @@ public class OrganismController extends VisualizerBaseController {
      * Response format:
      * <pre>
      * {
-     *   "runId": "string",
-     *   "tick": 1234,
      *   "organismId": 1,
-     *   "static": { ... },
-     *   "state": { ... }
+     *   "tick": 1234,
+     *   "staticInfo": { ... },
+     *   "state": { ... },
+     *   "genomeAncestors": { "genomeHash": "parentGenomeHash or null", ... }
      * }
      * </pre>
      *

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
@@ -16,9 +16,11 @@ import org.evochora.datapipeline.api.resources.database.TickNotFoundException;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
 import org.evochora.datapipeline.api.resources.database.dto.TickRange;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.evochora.node.processes.http.api.pipeline.dto.ErrorResponseDto;
+import org.evochora.node.processes.http.api.visualizer.dto.OrganismDetailsResponseDto;
 import org.evochora.node.processes.http.api.visualizer.dto.OrganismsResponseDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,13 +138,11 @@ public class OrganismController extends VisualizerBaseController {
 
             final List<OrganismTickSummary> organisms = reader.readOrganismsAtTick(tickNumber);
             final int totalOrganismCount = reader.readTotalOrganismsCreated(tickNumber);
-            final Map<Long, Long> genomeTree = reader.readGenomeLineageTree(tickNumber);
 
-            // Convert Long keys/values to String to preserve 64-bit precision in JSON
-            final Map<String, String> stringTree = new LinkedHashMap<>(genomeTree.size());
-            genomeTree.forEach((k, v) -> stringTree.put(String.valueOf(k), v != null ? String.valueOf(v) : null));
+            final List<Long> genomes = organisms.stream().map(o -> o.genomeHash).toList();
+            final Map<String, String> genomeAncestors = toStringMap(reader.readGenomeAncestors(genomes));
 
-            ctx.status(HttpStatus.OK).json(new OrganismsResponseDto(organisms, totalOrganismCount, stringTree));
+            ctx.status(HttpStatus.OK).json(new OrganismsResponseDto(organisms, totalOrganismCount, genomeAncestors));
         } catch (RuntimeException e) {
             handleDatabaseException(e, runId, "organisms");
         } catch (SQLException e) {
@@ -216,8 +216,14 @@ public class OrganismController extends VisualizerBaseController {
 
             final OrganismTickDetails details = reader.readOrganismDetails(tickNumber, organismId);
 
-            // Return DTO directly (contains all fields including state.instructions)
-            ctx.status(HttpStatus.OK).json(details);
+            // The ancestry chain is coloured by genome, so the response carries the closure of the
+            // genomes it names rather than relying on what the tick response happened to deliver.
+            final List<Long> genomes = new ArrayList<>();
+            details.staticInfo.lineage.forEach(entry -> genomes.add(entry.genomeHash()));
+            final Map<String, String> genomeAncestors = toStringMap(reader.readGenomeAncestors(genomes));
+
+            ctx.status(HttpStatus.OK).json(new OrganismDetailsResponseDto(
+                details.organismId, details.tick, details.staticInfo, details.state, genomeAncestors));
         } catch (OrganismNotFoundException e) {
             throw e;
         } catch (RuntimeException e) {
@@ -228,6 +234,23 @@ public class OrganismController extends VisualizerBaseController {
             }
             throw e;
         }
+    }
+
+
+    /**
+     * Converts a genome ancestor map to string keys and values.
+     * <p>
+     * Genome hashes are 64-bit and lose precision as JSON numbers, so they travel as strings.
+     * A null value marks a root genome and is preserved as null.
+     *
+     * @param ancestors Genome hash to parent genome hash, null value for roots
+     * @return The same mapping with string keys and values
+     */
+    private static Map<String, String> toStringMap(final Map<Long, Long> ancestors) {
+        final Map<String, String> result = new LinkedHashMap<>(ancestors.size());
+        ancestors.forEach((genome, parent) ->
+            result.put(String.valueOf(genome), parent != null ? String.valueOf(parent) : null));
+        return result;
     }
 
     /**

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
@@ -188,7 +188,7 @@ public class OrganismController extends VisualizerBaseController {
             @OpenApiParam(name = "runId", description = "Optional simulation run ID (defaults to latest run)", required = false)
         },
         responses = {
-            @OpenApiResponse(status = "200", description = "OK", content = @OpenApiContent(from = OrganismTickDetails.class)),
+            @OpenApiResponse(status = "200", description = "OK", content = @OpenApiContent(from = OrganismDetailsResponseDto.class)),
             @OpenApiResponse(status = "304", description = "Not Modified (cached response, ETag matches)"),
             @OpenApiResponse(status = "400", description = "Bad request (invalid tick or organismId)", content = @OpenApiContent(from = ErrorResponseDto.class)),
             @OpenApiResponse(status = "404", description = "Not found (organism, tick, or run ID not found)", content = @OpenApiContent(from = ErrorResponseDto.class)),

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/OrganismController.java
@@ -12,6 +12,7 @@ import io.javalin.openapi.OpenApiResponse;
 import org.evochora.datapipeline.api.resources.database.IDatabaseReader;
 import org.evochora.datapipeline.api.resources.database.OrganismNotFoundException;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickDetails;
+import org.evochora.datapipeline.api.resources.database.TickNotFoundException;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
 import org.evochora.datapipeline.api.resources.database.dto.TickRange;
 
@@ -115,7 +116,7 @@ public class OrganismController extends VisualizerBaseController {
             @OpenApiResponse(status = "500", description = "Internal server error (database error)", content = @OpenApiContent(from = ErrorResponseDto.class))
         }
     )
-    void getOrganismsAtTick(final Context ctx) throws SQLException {
+    void getOrganismsAtTick(final Context ctx) throws SQLException, TickNotFoundException {
         final long tickNumber = parseTickNumber(ctx.pathParam("tick"));
         final String runId = resolveRunId(ctx);
 

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/dto/OrganismDetailsResponseDto.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/dto/OrganismDetailsResponseDto.java
@@ -1,0 +1,32 @@
+package org.evochora.node.processes.http.api.visualizer.dto;
+
+import org.evochora.datapipeline.api.resources.database.dto.OrganismRuntimeView;
+import org.evochora.datapipeline.api.resources.database.dto.OrganismStaticInfo;
+
+import java.util.Map;
+
+/**
+ * Response DTO for the organism details endpoint.
+ * <p>
+ * Carries the same fields as the reader's detail view, plus the ancestor closure of the genomes
+ * occurring in the organism's ancestry chain. The chain is coloured by genome like the organisms
+ * of a tick, and an ancestor can carry a genome that is not an ancestor genome of the displayed
+ * organism, so the closure of a tick does not cover it. Each response therefore carries what it
+ * needs to be rendered on its own.
+ * <p>
+ * Genome hashes are serialized as strings to preserve 64-bit precision in JSON
+ * (JavaScript numbers lose precision beyond 2^53).
+ *
+ * @param organismId Identifier of the organism
+ * @param tick Tick the state belongs to
+ * @param staticInfo Immutable organism data including its ancestry chain
+ * @param state Runtime state at the given tick
+ * @param genomeAncestors Mapping of genomeHash → parentGenomeHash as strings, null for root genomes
+ */
+public record OrganismDetailsResponseDto(
+    int organismId,
+    long tick,
+    OrganismStaticInfo staticInfo,
+    OrganismRuntimeView state,
+    Map<String, String> genomeAncestors
+) {}

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/dto/OrganismsResponseDto.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/dto/OrganismsResponseDto.java
@@ -10,17 +10,19 @@ import java.util.Map;
  * <p>
  * Contains the list of organisms at a specific tick (alive and recently dead),
  * the cumulative count of all organisms ever created up to that tick,
- * and the genome lineage tree for lineage-based color computation.
+ * and the ancestor closure of the genomes occurring in that list, which is what
+ * lineage-based colour computation needs.
  * <p>
  * Genome hashes are serialized as strings to preserve 64-bit precision in JSON
  * (JavaScript numbers lose precision beyond 2^53).
  *
  * @param organisms List of organism summaries at the specified tick
- * @param totalOrganismCount Total organisms created up to this tick (sequential IDs from 1)
- * @param genomeLineageTree Mapping of genomeHash → parentGenomeHash as strings (null for root genomes)
+ * @param totalOrganismCount Total organisms created up to this tick
+ * @param genomeAncestors Mapping of genomeHash → parentGenomeHash as strings, null for root genomes,
+ *                        covering every genome in the list and all of their ancestors
  */
 public record OrganismsResponseDto(
     List<OrganismTickSummary> organisms,
     int totalOrganismCount,
-    Map<String, String> genomeLineageTree
+    Map<String, String> genomeAncestors
 ) {}

--- a/src/main/resources/web/visualizer/js/AppController.js
+++ b/src/main/resources/web/visualizer/js/AppController.js
@@ -453,6 +453,11 @@ export class AppController {
             // API returns "static" not "staticInfo"
             const staticInfo = details.static || details.staticInfo;
             const state = details.state;
+
+            // The ancestry chain is coloured by genome, and its ancestors need not appear at the
+            // current tick, so their parent links arrive with this response and are added before
+            // anything is drawn.
+            this._mergeGenomeAncestors(details.genomeAncestors);
             
             if (details && staticInfo) {
                 // Resolve the program artifact once and give every view its context before any of
@@ -901,7 +906,7 @@ export class AppController {
             const organismResult = await organismPromise;
             const organisms = organismResult.organisms;
             this.state.totalOrganismCount = organismResult.totalOrganismCount;
-            this._applyGenomeLineageTree(organismResult.genomeLineageTree);
+            this._applyGenomeAncestors(organismResult.genomeAncestors);
             this.updateOrganismPanel(organisms, isForwardStep);
             this.minimapView?.setOwnershipColorResolver(this._minimapOwnershipColorResolver(organisms));
             this.minimapView?.updateOrganisms(
@@ -1012,7 +1017,7 @@ export class AppController {
         
         // Calculate organism counts (exclude dead organisms from alive count)
         const aliveCount = organisms.filter(o => !o.isDead).length;
-        const totalCount = this.state.totalOrganismCount || organisms.length;
+        const totalCount = this.state.totalOrganismCount;
         
         // Update panel info (alive/total display)
         this.organismPanelManager?.updateInfo(aliveCount, totalCount);
@@ -1066,17 +1071,36 @@ export class AppController {
     }
 
     /**
-     * Applies the genome lineage tree from the backend API response.
+     * Applies the genome ancestor closure from a backend API response.
      * Replaces the genome→parentGenome map and clears derived color caches.
-     * @param {Object} tree - Map of genomeHash → parentGenomeHash (null for roots), from API response.
+     * <p>
+     * The map is replaced rather than merged: while a run is still being indexed, a genome whose
+     * parent organism has not been written yet reads as a root, and that answer corrects itself
+     * once the missing rows arrive. Keeping earlier answers would make such a colour last for the
+     * whole session.
+     * @param {Object} ancestors - Map of genomeHash → parentGenomeHash (null for roots), covering
+     *                             every genome the response displays and all of their ancestors.
      * @private
      */
-    _applyGenomeLineageTree(tree) {
-        if (!tree) return;
+    _applyGenomeAncestors(ancestors) {
         this._genomeParent.clear();
         this._genomeColorCache.clear();
         this._genomeHslCache.clear();
-        for (const [genomeHash, parentGenomeHash] of Object.entries(tree)) {
+        this._mergeGenomeAncestors(ancestors);
+    }
+
+    /**
+     * Adds a genome ancestor closure to the current one without discarding it.
+     * <p>
+     * A view is served by more than one response: the organisms of a tick and, when one is
+     * selected, its ancestry chain. Their closures overlap but neither contains the other, and
+     * both come from the same relation, so a genome present in both carries the same parent.
+     * Adding is therefore safe, while replacing would drop what the other response delivered.
+     * @param {Object} ancestors - Map of genomeHash → parentGenomeHash (null for roots).
+     * @private
+     */
+    _mergeGenomeAncestors(ancestors) {
+        for (const [genomeHash, parentGenomeHash] of Object.entries(ancestors)) {
             this._genomeParent.set(String(genomeHash), parentGenomeHash ? String(parentGenomeHash) : null);
         }
     }
@@ -1114,17 +1138,19 @@ export class AppController {
      * If the genome has a known parent, the color is derived by shifting the parent's hue.
      * Otherwise, a new root color is assigned via the golden-ratio sequence.
      * @param {string} genomeKey - String representation of the genome hash.
+     * @param {Set<string>} [visited] - Genomes already on the current path, guarding the recursion.
      * @private
      */
-    _computeLineageColor(genomeKey) {
+    _computeLineageColor(genomeKey, visited = new Set()) {
         if (this._genomeColorCache.has(genomeKey)) return;
 
         const parentGenomeKey = this._genomeParent.get(genomeKey);
+        visited.add(genomeKey);
 
-        if (parentGenomeKey && parentGenomeKey !== '0' && parentGenomeKey !== genomeKey) {
+        if (parentGenomeKey && parentGenomeKey !== '0' && !visited.has(parentGenomeKey)) {
             // Ensure parent color is computed first (recursive)
             if (!this._genomeColorCache.has(parentGenomeKey)) {
-                this._computeLineageColor(parentGenomeKey);
+                this._computeLineageColor(parentGenomeKey, visited);
             }
 
             const parentHsl = this._genomeHslCache.get(parentGenomeKey);

--- a/src/main/resources/web/visualizer/js/api/OrganismApi.js
+++ b/src/main/resources/web/visualizer/js/api/OrganismApi.js
@@ -43,11 +43,11 @@ export class OrganismApi {
 
         const data = await apiClient.fetch(url, fetchOptions);
 
-        // API response shape: { organisms: [...], totalOrganismCount: N }
+        // API response shape: { organisms: [...], totalOrganismCount: N, genomeAncestors: {...} }
         return {
-            organisms: Array.isArray(data.organisms) ? data.organisms : [],
-            totalOrganismCount: data.totalOrganismCount || 0,
-            genomeLineageTree: data.genomeLineageTree || {}
+            organisms: data.organisms,
+            totalOrganismCount: data.totalOrganismCount,
+            genomeAncestors: data.genomeAncestors
         };
     }
 

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
@@ -1,6 +1,7 @@
 package org.evochora.datapipeline.resources.database;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
@@ -18,6 +19,7 @@ import org.evochora.datapipeline.api.contracts.TickData;
 import org.evochora.datapipeline.api.contracts.Vector;
 import org.evochora.datapipeline.api.resources.database.IDatabaseReader;
 import org.evochora.datapipeline.api.resources.database.OrganismNotFoundException;
+import org.evochora.datapipeline.api.resources.database.TickNotFoundException;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismRuntimeView;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickDetails;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
@@ -112,6 +114,87 @@ class H2DatabaseOrganismReaderTest {
         try (IDatabaseReader reader = database.createReader("run-reader-2")) {
             List<OrganismTickSummary> organisms = reader.readOrganismsAtTick(2L);
             assertThat(organisms).isEmpty();
+        }
+    }
+
+    @Test
+    void readTotalOrganismsCreated_returnsTheValueTheTickReported() throws Exception {
+        TickData tick = TickData.newBuilder()
+                .setTickNumber(1L)
+                .addOrganisms(buildOrganismState(1))
+                .setTotalOrganismsCreated(4711L)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-total-1")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-total-1")) {
+            assertThat(reader.readTotalOrganismsCreated(1L)).isEqualTo(4711);
+        }
+    }
+
+    @Test
+    void readTotalOrganismsCreated_storesATotalForATickWithoutOrganisms() throws Exception {
+        TickData extinction = TickData.newBuilder()
+                .setTickNumber(2L)
+                .setTotalOrganismsCreated(1234L)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-total-2")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, extinction);
+            database.doCommitOrganismWrites(conn);
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-total-2")) {
+            assertThat(reader.readOrganismsAtTick(2L)).isEmpty();
+            assertThat(reader.readTotalOrganismsCreated(2L)).isEqualTo(1234);
+        }
+    }
+
+    @Test
+    void readTotalOrganismsCreated_survivesAReprocessedTick() throws Exception {
+        TickData tick = TickData.newBuilder()
+                .setTickNumber(3L)
+                .addOrganisms(buildOrganismState(1))
+                .setTotalOrganismsCreated(99L)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-total-3")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+            // At-least-once delivery: the same chunk can arrive again
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-total-3")) {
+            assertThat(reader.readTotalOrganismsCreated(3L)).isEqualTo(99);
+        }
+    }
+
+    @Test
+    void readTotalOrganismsCreated_throwsForATickThatWasNeverIndexed() throws Exception {
+        TickData tick = TickData.newBuilder()
+                .setTickNumber(1L)
+                .addOrganisms(buildOrganismState(1))
+                .setTotalOrganismsCreated(7L)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-total-4")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-total-4")) {
+            assertThatThrownBy(() -> reader.readTotalOrganismsCreated(2L))
+                    .isInstanceOf(TickNotFoundException.class)
+                    .hasMessageContaining("2");
         }
     }
 

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 
 import org.evochora.datapipeline.TestMetadataHelper;
@@ -111,6 +112,46 @@ class H2DatabaseOrganismReaderTest {
         try (IDatabaseReader reader = database.createReader("run-reader-2")) {
             List<OrganismTickSummary> organisms = reader.readOrganismsAtTick(2L);
             assertThat(organisms).isEmpty();
+        }
+    }
+
+    @Test
+    void readOrganismsAtTick_takesStaticFieldsFromTheStoredState() throws Exception {
+        OrganismState child = buildOrganismState(2).toBuilder()
+                .setParentId(1)
+                .setBirthTick(17L)
+                .setGenomeHash(-4242L)
+                .build();
+        TickData tick = TickData.newBuilder()
+                .setTickNumber(1L)
+                .addOrganisms(buildOrganismState(1))
+                .addOrganisms(child)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-reader-static")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+
+            // The summary must be answerable from the stored state alone. Emptying the static
+            // table makes any remaining dependency on it fail rather than pass unnoticed.
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("DELETE FROM organisms");
+            }
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-reader-static")) {
+            List<OrganismTickSummary> organisms = reader.readOrganismsAtTick(1L);
+
+            assertThat(organisms).hasSize(2);
+            OrganismTickSummary root = organisms.get(0);
+            assertThat(root.parentId).isNull();
+
+            OrganismTickSummary offspring = organisms.get(1);
+            assertThat(offspring.parentId).isEqualTo(1);
+            assertThat(offspring.birthTick).isEqualTo(17L);
+            assertThat(offspring.genomeHash).isEqualTo(-4242L);
         }
     }
 

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseOrganismReaderTest.java
@@ -178,6 +178,35 @@ class H2DatabaseOrganismReaderTest {
     }
 
     @Test
+    void readTotalOrganismsCreated_failsRatherThanTruncatingAnOversizedTotal() throws Exception {
+        // The API returns int because organism ids are INT, so a run cannot exceed that range
+        // without overflowing the ids themselves. Should a stored total ever exceed it anyway,
+        // the contract promises a failure rather than a wrong number.
+        TickData tick = TickData.newBuilder()
+                .setTickNumber(1L)
+                .addOrganisms(buildOrganismState(1))
+                .setTotalOrganismsCreated(1L)
+                .build();
+
+        try (Connection conn = getConnectionWithSchema("run-total-overflow")) {
+            database.doCreateOrganismTables(conn);
+            database.doWriteOrganismTick(conn, tick);
+            database.doCommitOrganismWrites(conn);
+
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("UPDATE organism_tick_stats SET total_organisms_created = "
+                        + (Integer.MAX_VALUE + 1L) + " WHERE tick_number = 1");
+            }
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = database.createReader("run-total-overflow")) {
+            assertThatThrownBy(() -> reader.readTotalOrganismsCreated(1L))
+                    .isInstanceOf(SQLException.class);
+        }
+    }
+
+    @Test
     void readTotalOrganismsCreated_throwsForATickThatWasNeverIndexed() throws Exception {
         TickData tick = TickData.newBuilder()
                 .setTickNumber(1L)

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderTest.java
@@ -299,7 +299,7 @@ class H2DatabaseReaderTest {
         }
     }
 
-    // --- readGenomeLineageTree tests ---
+    // --- readGenomeAncestors tests ---
 
     /**
      * Inserts a row into the organisms table with minimal required fields.
@@ -313,7 +313,7 @@ class H2DatabaseReaderTest {
     }
 
     /**
-     * Creates schema and organism tables for lineage tree tests.
+     * Creates schema and organism tables for ancestor tests.
      */
     private Connection setupOrganismSchema() throws Exception {
         Connection conn = (Connection) database.acquireDedicatedConnection();
@@ -325,7 +325,7 @@ class H2DatabaseReaderTest {
     }
 
     @Test
-    void readGenomeLineageTree_basicParentChildRelationships() throws Exception {
+    void readGenomeAncestors_walksTheChainOfTheRequestedGenome() throws Exception {
         try (Connection conn = setupOrganismSchema()) {
             insertOrganism(conn, 1, null, 0, 1000L);  // root
             insertOrganism(conn, 2, 1, 10, 2000L);    // child of 1, new genome
@@ -334,122 +334,194 @@ class H2DatabaseReaderTest {
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(3000L));
 
-            assertThat(tree).hasSize(3);
-            assertThat(tree.get(1000L)).isNull();          // root → null
-            assertThat(tree.get(2000L)).isEqualTo(1000L);  // child → parent genome
-            assertThat(tree.get(3000L)).isEqualTo(2000L);  // grandchild → parent genome
+            assertThat(ancestors).hasSize(3);
+            assertThat(ancestors.get(3000L)).isEqualTo(2000L);
+            assertThat(ancestors.get(2000L)).isEqualTo(1000L);
+            assertThat(ancestors.get(1000L)).isNull();
         }
     }
 
     @Test
-    void readGenomeLineageTree_rootGenomesMapToNull() throws Exception {
+    void readGenomeAncestors_carrierWithoutParentIsARoot() throws Exception {
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 1000L);  // primordial, no parent
-            insertOrganism(conn, 2, null, 0, 2000L);  // primordial, no parent
+            insertOrganism(conn, 1, null, 0, 1000L);
+            insertOrganism(conn, 2, null, 0, 2000L);
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(1000L, 2000L));
 
-            assertThat(tree).hasSize(2);
-            assertThat(tree.get(1000L)).isNull();
-            assertThat(tree.get(2000L)).isNull();
+            assertThat(ancestors).hasSize(2);
+            assertThat(ancestors).containsKey(1000L).containsKey(2000L);
+            assertThat(ancestors.get(1000L)).isNull();
+            assertThat(ancestors.get(2000L)).isNull();
         }
     }
 
     @Test
-    void readGenomeLineageTree_excludesGenomeHashZero() throws Exception {
+    void readGenomeAncestors_parentCarryingGenomeZeroIsARoot() throws Exception {
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 0L);     // genome=0, should be excluded
-            insertOrganism(conn, 2, null, 0, 1000L);   // normal genome
+            insertOrganism(conn, 1, null, 0, 0L);      // parent without a genome
+            insertOrganism(conn, 2, 1, 10, 2000L);
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(2000L));
 
-            assertThat(tree).hasSize(1);
-            assertThat(tree).containsKey(1000L);
-            assertThat(tree).doesNotContainKey(0L);
+            assertThat(ancestors).hasSize(1);
+            assertThat(ancestors.get(2000L)).isNull();
         }
     }
 
     @Test
-    void readGenomeLineageTree_filtersSelfReferencingGenomes() throws Exception {
-        // Org 2 inherits same genome as parent (no mutation) — should not create a self-referencing entry
+    void readGenomeAncestors_missingParentRowIsARoot() throws Exception {
+        // While a run is still being indexed the parent's row can be absent
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 1000L);   // root
-            insertOrganism(conn, 2, 1, 10, 1000L);     // same genome as parent (no mutation)
-            insertOrganism(conn, 3, 2, 20, 2000L);     // new genome, parent is org 2 (genome 1000)
+            insertOrganism(conn, 2, 1, 10, 2000L);     // parent 1 is not indexed
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(2000L));
 
-            assertThat(tree).hasSize(2);
-            assertThat(tree.get(1000L)).isNull();          // root (org 1 provides this)
-            assertThat(tree.get(2000L)).isEqualTo(1000L);  // derived from genome 1000
+            assertThat(ancestors).hasSize(1);
+            assertThat(ancestors.get(2000L)).isNull();
         }
     }
 
     @Test
-    void readGenomeLineageTree_firstOccurrenceWinsForDuplicateGenomes() throws Exception {
-        // Two organisms independently mutate to the same genome hash (collision).
-        // The first by organism_id should determine the parent.
+    void readGenomeAncestors_ignoresGenomeHashZero() throws Exception {
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 1000L);   // root A
-            insertOrganism(conn, 2, null, 0, 2000L);   // root B
-            insertOrganism(conn, 3, 1, 10, 3000L);     // derived from A
-            insertOrganism(conn, 4, 2, 10, 3000L);     // same genome 3000, but from B
+            insertOrganism(conn, 1, null, 0, 0L);
+            insertOrganism(conn, 2, null, 0, 1000L);
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(0L, 1000L));
 
-            assertThat(tree.get(3000L)).isEqualTo(1000L);  // org 3 (lower ID) wins → parent is 1000
+            assertThat(ancestors).hasSize(1);
+            assertThat(ancestors).containsKey(1000L).doesNotContainKey(0L);
         }
     }
 
     @Test
-    void readGenomeLineageTree_respectsBirthTickFilter() throws Exception {
+    void readGenomeAncestors_omitsGenomesThatDoNotOccur() throws Exception {
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 1000L);    // born at tick 0
-            insertOrganism(conn, 2, 1, 50, 2000L);      // born at tick 50
-            insertOrganism(conn, 3, 2, 100, 3000L);     // born at tick 100
+            insertOrganism(conn, 1, null, 0, 1000L);
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            // Query at tick 60 — should only include organisms born ≤ 60
-            Map<Long, Long> tree = reader.readGenomeLineageTree(60);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(1000L, 9999L));
 
-            assertThat(tree).hasSize(2);
-            assertThat(tree).containsKey(1000L);
-            assertThat(tree).containsKey(2000L);
-            assertThat(tree).doesNotContainKey(3000L);
+            assertThat(ancestors).hasSize(1);
+            assertThat(ancestors).containsKey(1000L).doesNotContainKey(9999L);
         }
     }
 
     @Test
-    void readGenomeLineageTree_parentWithGenomeZeroMapsToNull() throws Exception {
-        // Parent exists but has genome_hash=0 — child should be treated as root
+    void readGenomeAncestors_skipsCarriersThatInheritedTheirGenomeUnchanged() throws Exception {
+        // Filtering precedes ordering: organism 2 carries genome 1000 unchanged and must not be
+        // chosen as its first carrier, which would make genome 1000 its own ancestor.
         try (Connection conn = setupOrganismSchema()) {
-            insertOrganism(conn, 1, null, 0, 0L);      // parent with genome=0
-            insertOrganism(conn, 2, 1, 10, 2000L);     // child — parent genome is 0
+            insertOrganism(conn, 1, null, 0, 1000L);
+            insertOrganism(conn, 2, 1, 10, 1000L);     // same genome as its parent
+            insertOrganism(conn, 3, 2, 20, 2000L);
             conn.commit();
         }
 
         try (IDatabaseReader reader = provider.createReader(runId)) {
-            Map<Long, Long> tree = reader.readGenomeLineageTree(100);
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(2000L));
 
-            assertThat(tree).hasSize(1);
-            assertThat(tree.get(2000L)).isNull();  // treated as root (parent genome=0)
+            assertThat(ancestors).hasSize(2);
+            assertThat(ancestors.get(2000L)).isEqualTo(1000L);
+            assertThat(ancestors.get(1000L)).isNull();
+        }
+    }
+
+    @Test
+    void readGenomeAncestors_firstCarrierWinsWhenAGenomeAppearsTwice() throws Exception {
+        // Two organisms independently arrive at the same genome hash from different parents.
+        try (Connection conn = setupOrganismSchema()) {
+            insertOrganism(conn, 1, null, 0, 1000L);
+            insertOrganism(conn, 2, null, 0, 2000L);
+            insertOrganism(conn, 3, 1, 10, 3000L);     // from genome 1000
+            insertOrganism(conn, 4, 2, 10, 3000L);     // same genome, from genome 2000
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(3000L));
+
+            assertThat(ancestors.get(3000L)).isEqualTo(1000L);
+        }
+    }
+
+    @Test
+    void readGenomeAncestors_doesNotDependOnTheTickRequested() throws Exception {
+        // The first carrier of a visible genome was born no later than the tick it is visible at,
+        // so the answer is the same whether later organisms exist or not.
+        try (Connection conn = setupOrganismSchema()) {
+            insertOrganism(conn, 1, null, 0, 1000L);
+            insertOrganism(conn, 2, 1, 50, 2000L);
+            conn.commit();
+        }
+
+        Map<Long, Long> before;
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            before = reader.readGenomeAncestors(List.of(2000L));
+        }
+
+        try (Connection conn = setupOrganismSchema()) {
+            insertOrganism(conn, 3, 2, 100, 3000L);    // a later genome joins the run
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            assertThat(reader.readGenomeAncestors(List.of(2000L))).isEqualTo(before);
+        }
+    }
+
+    @Test
+    void readGenomeAncestors_sharedAncestorsAppearOnceEach() throws Exception {
+        try (Connection conn = setupOrganismSchema()) {
+            insertOrganism(conn, 1, null, 0, 1000L);
+            insertOrganism(conn, 2, 1, 10, 2000L);     // both descend from genome 1000
+            insertOrganism(conn, 3, 1, 10, 3000L);
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(2000L, 3000L, 2000L));
+
+            assertThat(ancestors).hasSize(3);
+            assertThat(ancestors.get(2000L)).isEqualTo(1000L);
+            assertThat(ancestors.get(3000L)).isEqualTo(1000L);
+            assertThat(ancestors.get(1000L)).isNull();
+        }
+    }
+
+    @Test
+    void readGenomeAncestors_terminatesOnCyclicData() throws Exception {
+        // Organism ids make a cycle impossible in data the pipeline writes, because a parent is
+        // always created before its child. The walk must terminate even if that does not hold.
+        try (Connection conn = setupOrganismSchema()) {
+            insertOrganism(conn, 1, 2, 0, 1000L);
+            insertOrganism(conn, 2, 1, 0, 2000L);
+            conn.commit();
+        }
+
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            Map<Long, Long> ancestors = reader.readGenomeAncestors(List.of(1000L));
+
+            assertThat(ancestors).hasSize(2);
+            assertThat(ancestors.get(1000L)).isEqualTo(2000L);
+            assertThat(ancestors.get(2000L)).isEqualTo(1000L);
         }
     }
 }
-

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseTest.java
@@ -163,19 +163,6 @@ class H2DatabaseTest {
     }
 
     @Test
-    void testMetrics_CacheSizeAvailable() {
-        // Verify H2 cache size metric is queryable
-        Map<String, Number> metrics = database.getMetrics();
-        
-        // Cache size might not be available in all H2 configurations, but method should not throw
-        // If available, it should be a non-negative number
-        Number cacheSize = metrics.get("h2_cache_size_bytes");
-        if (cacheSize != null) {
-            assertTrue(cacheSize.longValue() >= 0, "Cache size should be non-negative");
-        }
-    }
-
-    @Test
     @ExpectLog(level = LogLevel.ERROR, messagePattern = "H2 database 'test-db' cannot acquire a connection for .*")
     void testFailedConnectionAcquisition_MarksResourceFailed() {
         assertTrue(database.isHealthy(), "Fresh database should be healthy");

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseTest.java
@@ -5,16 +5,21 @@
 package org.evochora.datapipeline.resources.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.UUID;
 
+import org.evochora.datapipeline.api.resources.IResource;
+import org.evochora.junit.extensions.logging.ExpectLog;
+import org.evochora.junit.extensions.logging.LogLevel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -168,6 +173,27 @@ class H2DatabaseTest {
         if (cacheSize != null) {
             assertTrue(cacheSize.longValue() >= 0, "Cache size should be non-negative");
         }
+    }
+
+    @Test
+    @ExpectLog(level = LogLevel.ERROR, messagePattern = "H2 database 'test-db' cannot acquire a connection for .*")
+    void testFailedConnectionAcquisition_MarksResourceFailed() {
+        assertTrue(database.isHealthy(), "Fresh database should be healthy");
+        assertEquals(IResource.UsageState.ACTIVE, database.getUsageState("reader"));
+
+        // A closed pool can no longer hand out connections, which makes the database
+        // unusable for every caller - the same observable condition as a dead H2 store.
+        H2Database closed = database;
+        database = null;
+        closed.close();
+
+        assertThrows(SQLException.class, () -> closed.createReader("SIM_TEST"));
+
+        assertFalse(closed.isHealthy(), "Database that cannot hand out connections is not healthy");
+        assertEquals(IResource.UsageState.FAILED, closed.getUsageState("reader"));
+        assertTrue(closed.getErrors().stream()
+                .anyMatch(error -> "CONNECTION_ACQUIRE_FAILED".equals(error.errorType())),
+            "Failed acquisition must be recorded so the resource state is visible");
     }
 }
 

--- a/src/test/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategyTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategyTest.java
@@ -97,15 +97,16 @@ class RowPerOrganismStrategyTest {
         // When: Create tables
         strategy.createTables(mockConnection);
 
-        // Then: Should execute CREATE TABLE for organisms, organism_states, and index
-        verify(mockStatement, times(3)).execute(anyString());
+        // Then: Should execute CREATE TABLE for organisms, organism_states, the index
+        //       and organism_tick_stats
+        verify(mockStatement, times(4)).execute(anyString());
 
         // Verify SQL strings
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(mockStatement, times(3)).execute(sqlCaptor.capture());
+        verify(mockStatement, times(4)).execute(sqlCaptor.capture());
 
         List<String> executedSql = sqlCaptor.getAllValues();
-        assertThat(executedSql).hasSize(3);
+        assertThat(executedSql).hasSize(4);
 
         // First call: CREATE TABLE organisms
         assertThat(executedSql.get(0))
@@ -131,6 +132,12 @@ class RowPerOrganismStrategyTest {
         assertThat(executedSql.get(2))
                 .contains("CREATE INDEX IF NOT EXISTS idx_organism_states_org")
                 .contains("organism_states (organism_id)");
+
+        // Fourth call: CREATE TABLE organism_tick_stats
+        assertThat(executedSql.get(3))
+                .contains("CREATE TABLE IF NOT EXISTS organism_tick_stats")
+                .contains("tick_number BIGINT PRIMARY KEY")
+                .contains("total_organisms_created BIGINT NOT NULL");
     }
 
     @Test
@@ -145,9 +152,9 @@ class RowPerOrganismStrategyTest {
         strategy.addOrganismTick(mockConnection, tick);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch for 3 organism metadata + 3 state rows = 6
-        verify(mockPreparedStatement, times(6)).addBatch();
-        verify(mockPreparedStatement, times(2)).executeBatch();
+        // Then: addBatch for 3 organism metadata + 1 tick statistics + 3 state rows = 7
+        verify(mockPreparedStatement, times(7)).addBatch();
+        verify(mockPreparedStatement, times(3)).executeBatch();
     }
 
     @Test
@@ -166,9 +173,10 @@ class RowPerOrganismStrategyTest {
         strategy.addOrganismTick(mockConnection, tick3);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch for 3 unique organism metadata (deduped) + 6 state rows = 9
-        verify(mockPreparedStatement, times(9)).addBatch();
-        verify(mockPreparedStatement, times(2)).executeBatch();
+        // Then: addBatch for 3 unique organism metadata (deduped) + 3 tick statistics
+        //       + 6 state rows = 12
+        verify(mockPreparedStatement, times(12)).addBatch();
+        verify(mockPreparedStatement, times(3)).executeBatch();
     }
 
     @Test
@@ -203,8 +211,9 @@ class RowPerOrganismStrategyTest {
         strategy.addOrganismTick(mockConnection, tick2);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch 1 (organism metadata, deduped) + 2 (state rows) = 3
-        verify(mockPreparedStatement, times(3)).addBatch();
+        // Then: addBatch 1 (organism metadata, deduped) + 2 (tick statistics)
+        //       + 2 (state rows) = 5
+        verify(mockPreparedStatement, times(5)).addBatch();
     }
 
     @Test
@@ -227,8 +236,9 @@ class RowPerOrganismStrategyTest {
         strategy.addOrganismTick(mockConnection, tick2);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: 3 unique organism metadata + 4 state rows (2+2) = 7 addBatch calls
-        verify(mockPreparedStatement, times(7)).addBatch();
+        // Then: 3 unique organism metadata + 2 tick statistics + 4 state rows (2+2)
+        //       = 9 addBatch calls
+        verify(mockPreparedStatement, times(9)).addBatch();
     }
 
     @Test

--- a/src/test/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategyTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/h2/RowPerOrganismStrategyTest.java
@@ -97,16 +97,16 @@ class RowPerOrganismStrategyTest {
         // When: Create tables
         strategy.createTables(mockConnection);
 
-        // Then: Should execute CREATE TABLE for organisms, organism_states, the index
-        //       and organism_tick_stats
-        verify(mockStatement, times(4)).execute(anyString());
+        // Then: Should execute DDL for organisms, organism_states, the per-organism index,
+        //       organism_tick_stats and the genome index
+        verify(mockStatement, times(5)).execute(anyString());
 
         // Verify SQL strings
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(mockStatement, times(4)).execute(sqlCaptor.capture());
+        verify(mockStatement, times(5)).execute(sqlCaptor.capture());
 
         List<String> executedSql = sqlCaptor.getAllValues();
-        assertThat(executedSql).hasSize(4);
+        assertThat(executedSql).hasSize(5);
 
         // First call: CREATE TABLE organisms
         assertThat(executedSql.get(0))
@@ -138,6 +138,11 @@ class RowPerOrganismStrategyTest {
                 .contains("CREATE TABLE IF NOT EXISTS organism_tick_stats")
                 .contains("tick_number BIGINT PRIMARY KEY")
                 .contains("total_organisms_created BIGINT NOT NULL");
+
+        // Fifth call: CREATE INDEX on the static organism data
+        assertThat(executedSql.get(4))
+                .contains("CREATE INDEX IF NOT EXISTS idx_organisms_genome")
+                .contains("organisms (genome_hash, organism_id)");
     }
 
     @Test

--- a/src/test/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategyTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategyTest.java
@@ -99,15 +99,16 @@ class SingleBlobOrgStrategyTest {
         // When: Create tables
         strategy.createTables(mockConnection);
         
-        // Then: Should execute CREATE TABLE for organisms, organism_ticks and organism_tick_stats
-        verify(mockStatement, times(3)).execute(anyString());
+        // Then: Should execute DDL for organisms, organism_ticks, organism_tick_stats
+        //       and the genome index
+        verify(mockStatement, times(4)).execute(anyString());
         
         // Verify SQL strings
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(mockStatement, times(3)).execute(sqlCaptor.capture());
+        verify(mockStatement, times(4)).execute(sqlCaptor.capture());
         
         List<String> executedSql = sqlCaptor.getAllValues();
-        assertThat(executedSql).hasSize(3);
+        assertThat(executedSql).hasSize(4);
         
         // First call: CREATE TABLE organisms
         assertThat(executedSql.get(0))
@@ -125,6 +126,11 @@ class SingleBlobOrgStrategyTest {
             .contains("CREATE TABLE IF NOT EXISTS organism_tick_stats")
             .contains("tick_number BIGINT PRIMARY KEY")
             .contains("total_organisms_created BIGINT NOT NULL");
+
+        // Fourth call: CREATE INDEX on the static organism data
+        assertThat(executedSql.get(3))
+            .contains("CREATE INDEX IF NOT EXISTS idx_organisms_genome")
+            .contains("organisms (genome_hash, organism_id)");
     }
     
     @Test

--- a/src/test/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategyTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/h2/SingleBlobOrgStrategyTest.java
@@ -2,6 +2,7 @@ package org.evochora.datapipeline.resources.database.h2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -98,15 +99,15 @@ class SingleBlobOrgStrategyTest {
         // When: Create tables
         strategy.createTables(mockConnection);
         
-        // Then: Should execute CREATE TABLE for both organisms and organism_ticks
-        verify(mockStatement, times(2)).execute(anyString());
+        // Then: Should execute CREATE TABLE for organisms, organism_ticks and organism_tick_stats
+        verify(mockStatement, times(3)).execute(anyString());
         
         // Verify SQL strings
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(mockStatement, times(2)).execute(sqlCaptor.capture());
+        verify(mockStatement, times(3)).execute(sqlCaptor.capture());
         
         List<String> executedSql = sqlCaptor.getAllValues();
-        assertThat(executedSql).hasSize(2);
+        assertThat(executedSql).hasSize(3);
         
         // First call: CREATE TABLE organisms
         assertThat(executedSql.get(0))
@@ -118,6 +119,12 @@ class SingleBlobOrgStrategyTest {
             .contains("CREATE TABLE IF NOT EXISTS organism_ticks")
             .contains("tick_number BIGINT PRIMARY KEY")
             .contains("organisms_blob BYTEA NOT NULL");
+
+        // Third call: CREATE TABLE organism_tick_stats
+        assertThat(executedSql.get(2))
+            .contains("CREATE TABLE IF NOT EXISTS organism_tick_stats")
+            .contains("tick_number BIGINT PRIMARY KEY")
+            .contains("total_organisms_created BIGINT NOT NULL");
     }
     
     @Test
@@ -132,10 +139,10 @@ class SingleBlobOrgStrategyTest {
         strategy.addOrganismTick(mockConnection, tick);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch called for 3 organism metadata + 1 state blob = 4
-        verify(mockPreparedStatement, times(4)).addBatch();
-        // executeBatch called for organisms batch + states batch
-        verify(mockPreparedStatement, times(2)).executeBatch();
+        // Then: addBatch called for 3 organism metadata + 1 tick statistics + 1 state blob = 5
+        verify(mockPreparedStatement, times(5)).addBatch();
+        // executeBatch called for organisms, states and tick statistics batches
+        verify(mockPreparedStatement, times(3)).executeBatch();
     }
 
     @Test
@@ -154,9 +161,10 @@ class SingleBlobOrgStrategyTest {
         strategy.addOrganismTick(mockConnection, tick3);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch for 3 unique organism metadata (deduped) + 3 state blobs = 6
-        verify(mockPreparedStatement, times(6)).addBatch();
-        verify(mockPreparedStatement, times(2)).executeBatch();
+        // Then: addBatch for 3 unique organism metadata (deduped) + 3 tick statistics
+        //       + 3 state blobs = 9
+        verify(mockPreparedStatement, times(9)).addBatch();
+        verify(mockPreparedStatement, times(3)).executeBatch();
     }
 
     @Test
@@ -234,9 +242,11 @@ class SingleBlobOrgStrategyTest {
         strategy.addOrganismTick(mockConnection, emptyTick);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: No organism metadata and no state blob (only executeBatch for states)
-        verify(mockPreparedStatement, never()).addBatch();
-        verify(mockPreparedStatement).executeBatch();
+        // Then: no organism metadata and no state blob, but the tick statistics are still
+        //       recorded - a tick without organisms is data, not absence of data
+        verify(mockPreparedStatement, times(1)).addBatch();
+        verify(mockPreparedStatement, never()).setBytes(anyInt(), any());
+        verify(mockPreparedStatement, times(2)).executeBatch();
     }
 
     @Test
@@ -271,8 +281,9 @@ class SingleBlobOrgStrategyTest {
         strategy.addOrganismTick(mockConnection, tick2);
         strategy.commitOrganismWrites(mockConnection);
 
-        // Then: addBatch called 1 (organism metadata, deduped) + 2 (state blobs) = 3
-        verify(mockPreparedStatement, times(3)).addBatch();
+        // Then: addBatch called 1 (organism metadata, deduped) + 2 (tick statistics)
+        //       + 2 (state blobs) = 5
+        verify(mockPreparedStatement, times(5)).addBatch();
     }
     
     @Test


### PR DESCRIPTION
Two related things: the resilience gap behind #113, and the cost that triggered it (#114).

## #113 — a resource that cannot serve anyone reported itself as healthy

The demo node's H2 database died twice and stayed dead for hours while `isHealthy()` returned `true` throughout. The cause was found in H2's own trace file: an `OutOfMemoryError` in a request thread panics the MVStore, which closes itself **and does not release its file lock**, so the same JVM can never reopen its own database — `OverlappingFileLockException`, forever. HikariCP behaved correctly the whole time, retrying every 5 s; `total=0` was a pool that could not create a single connection, not an exhausted one. Full evidence in [#113](https://github.com/evochora/evochora/issues/113).

Nothing recorded that. `AbstractResource`'s rule said fatal errors must be thrown but **not** recorded — "resource is broken anyway" — on the assumption that a fatal error stops the resource. Nothing stops it. It keeps running, throws on every call, and reports `ACTIVE`.

- The rule now separates the two concerns it conflated: recording reflects the state of the resource, throwing reports the outcome of one operation. Both can apply at once, which is what the database wrappers have been doing all along.
- `H2Database` records a failed connection acquisition, so `isHealthy()`, `getUsageState()` and `resources_failed` reflect a pool that can no longer hand out connections.
- System faults are logged **with** their stack trace, at ERROR. HikariCP chains the underlying failure into the timeout it throws; logging only the message discarded the diagnosis, and the rule sent stack traces to DEBUG, which production never sees.
- The `h2_cache_size_bytes` metric is removed. Its query used a reserved word, the wrong column names and the wrong setting name, so it failed every 30 seconds since March and was swallowed at DEBUG. Repairing it would have produced a value off by a factor of 1024, since H2 reports KB.

## #114 — three full table scans per organism snapshot

Each `GET /visualizer/api/organisms/{tick}` scanned the `organisms` table three times and carried a 6.6 MB lineage tree. None of the three remains.

**The static fields come from the state that already carries them.** Loading the whole table to look up `parent_id`, `birth_tick` and `genome_hash` cost ~1.5 GB of heap per in-flight request — the allocation behind #113. All three are in the blob the same method just read, and the table is written from exactly those values.

**The organism total is stored, not derived.** The simulation ships it with every tick; nothing persisted it, so it was reconstructed with a 5.9 s scan for one `(alive/total)` label. It now lives in `organism_tick_stats`, read by primary key. A tick with no row raises `TickNotFoundException` rather than reporting zero, which would be indistinguishable from a run that produced nothing.

**Ancestors instead of the whole tree.** Lineage colouring needs the ancestor closure of the genomes on screen, not the tree of every genome ever observed. `readGenomeAncestors` walks it over an indexed `organisms` table. The contract states the relation itself — how a first carrier is chosen, why filtering precedes ordering, that genome hash 0 is outside the relation, what a null value means against an absent key — because two implementations must produce identical answers.

A materialized lineage table was measured (+3 MB, sub-millisecond) and **rejected**: maintaining it at index time makes the derivation depend on commit order, which competing consumers and the DLQ path do not guarantee, and first-writer-wins would make the error permanent. A read-time derivation has the same exposure while a run is being indexed, but it corrects itself.

## Verified against the production database

On a reflink copy of the 33 GB demo database, in a throwaway container; the live node was never queried and is untouched.

| | scope | result |
|---|---|---|
| static fields: blob vs table | 4 604 organisms, 7 ticks across the run | 0 differences |
| organism total: stored vs derived | 6 ticks across 6 orders of magnitude | identical |
| **ancestor relation vs the old tree query** | **all 150 525 genomes, both directions** | **identical**, 5.8 s vs 10.7 s |
| closure of one view | 400 visible genomes → 719 entries | 222–240 ms warm, 903 ms first |
| index build | 14.6 M rows | 51 s, one-off |

Real shape of the run, measured rather than assumed: genome depth to root max **89**, median 19; **397** genomes alive simultaneously at a median tick, max 548; the ancestor closure of a view is **719 entries against 150 525** — a factor of 209.

A level-wise walk (`IN` list plus window function) was measured too and is **not** faster, neither embedded nor over H2 TCP; the contract permits it for a backend where round trips are expensive.

## What this does not do

**It does not make the demo node deployable.** That node runs a March image, and a current build cannot parse the organism blobs of any run recorded before the field renumbering of `8919f646` — `Protocol message had invalid UTF-8`, the exact consequence [PERSISTED_FORMAT_VERSIONING](../blob/main/docs/proposals/PERSISTED_FORMAT_VERSIONING.md) records as evidence. That blocked a browser check against the published run and is independent of this change. Merging neither improves nor worsens it.

Consequently there is no migration, detection or fallback for databases written by older builds, in line with that proposal.

## Notes for review

- The design is in `docs/proposals/GENOME_LINEAGE_INDEXING.md`, reviewed twice against the architecture guidelines before implementation; the approach changed after the first round.
- The visualizer's JavaScript has no test infrastructure, so the frontend change carries no automated tests. It was checked by hand on short runs.
- 2 209 tests green, PMD green.

Closes #114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added genome ancestry information to organism list and detail responses, including root genomes and shared ancestors.
  * Added organism detail responses with genome ancestry mappings.
  * Added accurate per-tick organism totals, including ticks with no organisms.
* **Bug Fixes**
  * Improved lineage visualization reliability by preventing cycles and using reported totals directly.
  * Connection failures now correctly mark the resource as failed and provide clearer error reporting.
* **Documentation**
  * Updated operational error-handling and stack-trace guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->