### PR TITLE
Thermodynamics: table-compiled rule resolution, single-pass costing, and no write thermodynamics for failed writes

### DIFF
--- a/src/main/java/org/evochora/runtime/thermodynamics/impl/PokeThermodynamicPolicy.java
+++ b/src/main/java/org/evochora/runtime/thermodynamics/impl/PokeThermodynamicPolicy.java
@@ -129,18 +129,9 @@ public class PokeThermodynamicPolicy implements IThermodynamicPolicy {
             return 0;
         }
         
-        // Check if target is already occupied (this happens during execution, but we check here via targetInfo)
-        // Exception: PPK instructions (PPKR, PPKI, PPKS) first execute PEEK which clears the cell,
-        // so POKE will always succeed - we should charge the cost even if target appears occupied.
-        String instructionName = context.instruction().getName();
-        boolean isPPK = "PPKR".equals(instructionName) || "PPKI".equals(instructionName) || "PPKS".equals(instructionName);
-        
-        if (!isPPK && context.targetInfo().isPresent()) {
-            var target = context.targetInfo().get();
-            if (!target.molecule().isEmpty()) {
-                // Target is occupied, POKE will fail - no cost
-                return 0;
-            }
+        if (!writeCharged(context)) {
+            // Target is occupied, POKE will fail - no cost
+            return 0;
         }
 
         Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
@@ -170,6 +161,11 @@ public class PokeThermodynamicPolicy implements IThermodynamicPolicy {
             return 0;
         }
 
+        if (!writeCharged(context)) {
+            // Target is occupied, POKE will fail - a failed write dissipates nothing either
+            return 0;
+        }
+
         Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
         if (toWrite != null) {
             Rule rule = typeRules.get(toWrite.type());
@@ -189,6 +185,21 @@ public class PokeThermodynamicPolicy implements IThermodynamicPolicy {
         return 0;
     }
     
+    /**
+     * Reports whether write costs are charged: PPK instructions always pay (their PEEK
+     * clears the cell first), any other write pays only when the target cell is empty,
+     * because a write onto an occupied cell fails in execution and a failed instruction
+     * carries no write thermodynamics - neither energy nor entropy.
+     */
+    private boolean writeCharged(ThermodynamicContext context) {
+        String instructionName = context.instruction().getName();
+        boolean isPPK = "PPKR".equals(instructionName) || "PPKI".equals(instructionName) || "PPKS".equals(instructionName);
+        if (isPPK) {
+            return true;
+        }
+        return context.targetInfo().isEmpty() || context.targetInfo().get().molecule().isEmpty();
+    }
+
     private Molecule getMoleculeToWrite(List<Operand> operands) {
         if (operands != null && !operands.isEmpty()) {
             // For POKE/POKI/POKS, the value to write is always the first operand.

--- a/src/main/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicy.java
+++ b/src/main/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicy.java
@@ -168,8 +168,13 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
     /** Write rules compiled per molecule-type slot, defaults pre-filled; {@code null} when absent. */
     private TypeRule[] writeTable;
 
-    /** Opcode ids of PPKR/PPKI/PPKS once resolved from the instruction registry. */
-    private int[] ppkOpcodes;
+    /**
+     * Opcode ids of PPKR/PPKI/PPKS once resolved from the instruction registry.
+     * Volatile so that the lazily created array is published safely: concurrent readers
+     * (cost calculation may run on worker threads for organism-local instructions) see
+     * either {@code null} or the fully initialized array, never a partial state.
+     */
+    private volatile int[] ppkOpcodes;
 
     @Override
     public void initialize(Config options) {
@@ -269,7 +274,7 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
      * The opcode ids are resolved from the instruction registry on first use; when the
      * registry is not initialized, the names are compared instead.
      */
-    private boolean isPpk(org.evochora.runtime.isa.Instruction instruction) {
+    private boolean isPpk(Instruction instruction) {
         int[] ids = this.ppkOpcodes;
         if (ids == null) {
             Integer r = Instruction.getInstructionIdByName("PPKR");
@@ -335,9 +340,9 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
             entropy += readRule.calculateEntropy(molecule);
         }
 
-        if (this.writeTable != null) {
+        if (this.writeTable != null && writeCharged(context)) {
             Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
-            if (toWrite != null && writeCharged(context)) {
+            if (toWrite != null) {
                 Rule writeRule = writeRuleFor(toWrite);
                 if (writeRule != null) {
                     energy += writeRule.calculateEnergy(toWrite);
@@ -348,52 +353,24 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
         return new Thermodynamics(energy, entropy);
     }
 
+    /**
+     * In this policy, energy and entropy are two results of the same rule resolution,
+     * so the individual getters derive their value from
+     * {@link #getThermodynamics(ThermodynamicContext)} instead of resolving again.
+     */
     @Override
     public int getEnergyCost(ThermodynamicContext context) {
-        ConflictResolutionStatus status = context.instruction().getConflictStatus();
-        if (status != ConflictResolutionStatus.WON_EXECUTION && status != ConflictResolutionStatus.NOT_APPLICABLE) {
-            // Instruction lost conflict or failed - only return base energy (if any)
-            return baseEnergy;
-        }
-        int total = baseEnergy;
-        Rule readRule = readRuleFor(context);
-        if (readRule != null) {
-            total += readRule.calculateEnergy(context.targetInfo().get().molecule());
-        }
-        if (this.writeTable != null) {
-            Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
-            if (toWrite != null && writeCharged(context)) {
-                Rule writeRule = writeRuleFor(toWrite);
-                if (writeRule != null) {
-                    total += writeRule.calculateEnergy(toWrite);
-                }
-            }
-        }
-        return total;
+        return getThermodynamics(context).energyCost();
     }
 
+    /**
+     * In this policy, energy and entropy are two results of the same rule resolution,
+     * so the individual getters derive their value from
+     * {@link #getThermodynamics(ThermodynamicContext)} instead of resolving again.
+     */
     @Override
     public int getEntropyDelta(ThermodynamicContext context) {
-        ConflictResolutionStatus status = context.instruction().getConflictStatus();
-        if (status != ConflictResolutionStatus.WON_EXECUTION && status != ConflictResolutionStatus.NOT_APPLICABLE) {
-            // Instruction lost conflict or failed - only return base entropy (if any)
-            return baseEntropy;
-        }
-        int total = baseEntropy;
-        Rule readRule = readRuleFor(context);
-        if (readRule != null) {
-            total += readRule.calculateEntropy(context.targetInfo().get().molecule());
-        }
-        if (this.writeTable != null) {
-            Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
-            if (toWrite != null && writeCharged(context)) {
-                Rule writeRule = writeRuleFor(toWrite);
-                if (writeRule != null) {
-                    total += writeRule.calculateEntropy(toWrite);
-                }
-            }
-        }
-        return total;
+        return getThermodynamics(context).entropyDelta();
     }
 
     /**

--- a/src/main/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicy.java
+++ b/src/main/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicy.java
@@ -1,6 +1,7 @@
 package org.evochora.runtime.thermodynamics.impl;
 
 import com.typesafe.config.Config;
+import org.evochora.runtime.isa.Instruction;
 import org.evochora.runtime.isa.Instruction.ConflictResolutionStatus;
 import org.evochora.runtime.isa.Instruction.Operand;
 import org.evochora.runtime.model.Molecule;
@@ -50,13 +51,21 @@ import java.util.Optional;
  * Each type rule supports an optional {@code values} sub-block for value-specific overrides.
  * When a molecule is evaluated, the policy first checks for a matching value override; if none
  * is found, it falls back to the type-level default rule.
+ * <p>
+ * This policy runs for every executed instruction, so rule resolution is on the simulation's
+ * hot path. The parsed rules are therefore compiled into arrays indexed by ownership and
+ * molecule type once during {@link #initialize(Config)}; per-instruction lookups are plain
+ * array accesses without boxing, and {@link #getThermodynamics(ThermodynamicContext)} resolves
+ * the context once for both the energy and the entropy result.
  */
 public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
 
     private static final Logger LOG = LoggerFactory.getLogger(UniversalThermodynamicPolicy.class);
-    
-    // Placeholder key for the default rule in maps
+
     private static final int DEFAULT_TYPE_KEY = -1;
+
+    /** One slot per possible value of the molecule's type field. */
+    private static final int TYPE_SLOTS = 1 << org.evochora.runtime.Config.TYPE_BITS;
 
     /**
      * Rule for calculating energy and entropy based on molecule values.
@@ -72,20 +81,17 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
             // Both fixed and permille can be specified simultaneously - they will be added
             this.energyFixed = config.hasPath("energy") ? config.getInt("energy") : 0;
             this.energyPerMille = config.hasPath("energy-permille") ? config.getInt("energy-permille") : 0;
-            
             // Entropy: at least one must be configured, but both can be present (they will be added)
             if (config.hasPath("entropy")) {
                 this.entropyFixed = config.getInt("entropy");
             } else {
                 this.entropyFixed = null;
             }
-            
             if (config.hasPath("entropy-permille")) {
                 this.entropyPerMille = config.getInt("entropy-permille");
             } else {
                 this.entropyPerMille = null;
             }
-            
             if (entropyFixed == null && entropyPerMille == null) {
                 // Entropy must be explicitly configured (at least one)
                 throw new IllegalStateException("Entropy not configured for UniversalThermodynamicPolicy rule. Must specify either 'entropy' or 'entropy-permille' (or both) in evochora.conf.");
@@ -102,7 +108,7 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
             }
             return fixed + permille; // Add both if both are configured
         }
-        
+
         int calculateEntropy(Molecule molecule) {
             int fixed = (entropyFixed != null) ? entropyFixed : 0;
             int permille = 0;
@@ -151,11 +157,19 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
     private int baseEnergy = 0;
     private int baseEntropy = 0;
 
-    // Read rules (applied when targetInfo is present)
-    private final Map<Ownership, Map<Integer, TypeRule>> readRules = new EnumMap<>(Ownership.class);
+    /**
+     * Read rules compiled per ownership and molecule-type slot; the type-level default
+     * rule is pre-filled into every slot without a specific rule. {@code null} when the
+     * configuration has no read rules; a row is all-{@code null} when its ownership class
+     * is not configured.
+     */
+    private TypeRule[][] readTable;
 
-    // Write rules (applied when a molecule is being written)
-    private final Map<Integer, TypeRule> writeRules = new HashMap<>();
+    /** Write rules compiled per molecule-type slot, defaults pre-filled; {@code null} when absent. */
+    private TypeRule[] writeTable;
+
+    /** Opcode ids of PPKR/PPKI/PPKS once resolved from the instruction registry. */
+    private int[] ppkOpcodes;
 
     @Override
     public void initialize(Config options) {
@@ -164,15 +178,14 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
         this.baseEntropy = options.hasPath("base-entropy") ? options.getInt("base-entropy") : 0;
 
         // Parse read-rules (if present)
+        Map<Ownership, Map<Integer, TypeRule>> readRules = new EnumMap<>(Ownership.class);
         if (options.hasPath("read-rules")) {
             Config readRulesConfig = options.getConfig("read-rules");
             for (Ownership ownership : Ownership.values()) {
                 String ownerKey = ownership.name().toLowerCase();
                 if (!readRulesConfig.hasPath(ownerKey)) continue;
-
                 Config ownerConfig = readRulesConfig.getConfig(ownerKey);
                 Map<Integer, TypeRule> typeRules = new HashMap<>();
-
                 for (String typeName : ownerConfig.root().keySet()) {
                     Config typeConfig = ownerConfig.getConfig(typeName);
                     if ("_default".equalsIgnoreCase(typeName)) {
@@ -191,6 +204,7 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
         }
 
         // Parse write-rules (if present)
+        Map<Integer, TypeRule> writeRules = new HashMap<>();
         if (options.hasPath("write-rules")) {
             Config writeRulesConfig = options.getConfig("write-rules");
             for (String key : writeRulesConfig.root().keySet()) {
@@ -207,128 +221,181 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
                 }
             }
         }
+
+        // Compile the parsed rules into per-slot tables: specific rule where configured,
+        // otherwise the type-level default, so per-instruction resolution is one array access.
+        if (!readRules.isEmpty()) {
+            this.readTable = new TypeRule[Ownership.values().length][];
+            for (Map.Entry<Ownership, Map<Integer, TypeRule>> entry : readRules.entrySet()) {
+                this.readTable[entry.getKey().ordinal()] = compileTypeTable(entry.getValue());
+            }
+            for (int i = 0; i < this.readTable.length; i++) {
+                if (this.readTable[i] == null) {
+                    this.readTable[i] = new TypeRule[TYPE_SLOTS];
+                }
+            }
+        } else {
+            this.readTable = null;
+        }
+        this.writeTable = writeRules.isEmpty() ? null : compileTypeTable(writeRules);
+    }
+
+    /** Expands a type-keyed rule map into one slot per possible molecule type. */
+    private static TypeRule[] compileTypeTable(Map<Integer, TypeRule> typeRules) {
+        TypeRule[] table = new TypeRule[TYPE_SLOTS];
+        TypeRule defaultRule = typeRules.get(DEFAULT_TYPE_KEY);
+        for (int slot = 0; slot < TYPE_SLOTS; slot++) {
+            TypeRule specific = typeRules.get(slot << org.evochora.runtime.Config.TYPE_SHIFT);
+            table[slot] = (specific != null) ? specific : defaultRule;
+        }
+        return table;
+    }
+
+    /** Maps a molecule's type field (already shifted) to its table slot. */
+    private static int typeSlot(int type) {
+        return (type & org.evochora.runtime.Config.TYPE_MASK) >>> org.evochora.runtime.Config.TYPE_SHIFT;
+    }
+
+    /** Classifies the target cell's owner relative to the executing organism. */
+    private static Ownership ownershipOf(ThermodynamicContext.TargetInfo target, int organismId) {
+        if (target.ownerId() == organismId) return Ownership.OWN;
+        if (target.ownerId() == 0) return Ownership.UNOWNED;
+        return Ownership.FOREIGN;
+    }
+
+    /**
+     * Reports whether the instruction is one of the PPK variants, which are charged write
+     * costs even on an occupied target because their preceding PEEK clears the cell.
+     * The opcode ids are resolved from the instruction registry on first use; when the
+     * registry is not initialized, the names are compared instead.
+     */
+    private boolean isPpk(org.evochora.runtime.isa.Instruction instruction) {
+        int[] ids = this.ppkOpcodes;
+        if (ids == null) {
+            Integer r = Instruction.getInstructionIdByName("PPKR");
+            Integer i = Instruction.getInstructionIdByName("PPKI");
+            Integer s = Instruction.getInstructionIdByName("PPKS");
+            if (r != null && i != null && s != null) {
+                ids = new int[]{r, i, s};
+                this.ppkOpcodes = ids;
+            } else {
+                String name = instruction.getName();
+                return "PPKR".equals(name) || "PPKI".equals(name) || "PPKS".equals(name);
+            }
+        }
+        int opcode = instruction.getFullOpcodeId();
+        return opcode == ids[0] || opcode == ids[1] || opcode == ids[2];
+    }
+
+    /** Resolves the read rule applying to the context's target cell, or {@code null}. */
+    private Rule readRuleFor(ThermodynamicContext context) {
+        if (this.readTable == null || context.targetInfo().isEmpty()) {
+            return null;
+        }
+        ThermodynamicContext.TargetInfo target = context.targetInfo().get();
+        Ownership ownership = ownershipOf(target, context.organism().getId());
+        TypeRule typeRule = this.readTable[ownership.ordinal()][typeSlot(target.molecule().type())];
+        return (typeRule != null) ? typeRule.resolve(target.molecule()) : null;
+    }
+
+    /** Resolves the write rule applying to the given molecule, or {@code null}. */
+    private Rule writeRuleFor(Molecule toWrite) {
+        TypeRule typeRule = this.writeTable[typeSlot(toWrite.type())];
+        return (typeRule != null) ? typeRule.resolve(toWrite) : null;
+    }
+
+    /**
+     * Reports whether write costs are charged: PPK instructions always pay (their PEEK
+     * clears the cell first); any other write pays only when the target cell is empty,
+     * because a write onto an occupied cell fails in execution and a failed instruction
+     * carries no write thermodynamics - neither energy nor entropy - only the error penalty.
+     */
+    private boolean writeCharged(ThermodynamicContext context) {
+        if (isPpk(context.instruction())) {
+            return true;
+        }
+        return context.targetInfo().isEmpty() || context.targetInfo().get().molecule().isEmpty();
+    }
+
+    @Override
+    public Thermodynamics getThermodynamics(ThermodynamicContext context) {
+        ConflictResolutionStatus status = context.instruction().getConflictStatus();
+        if (status != ConflictResolutionStatus.WON_EXECUTION && status != ConflictResolutionStatus.NOT_APPLICABLE) {
+            // Instruction lost conflict or failed - only the base values apply
+            return new Thermodynamics(baseEnergy, baseEntropy);
+        }
+
+        int energy = baseEnergy;
+        int entropy = baseEntropy;
+
+        Rule readRule = readRuleFor(context);
+        if (readRule != null) {
+            Molecule molecule = context.targetInfo().get().molecule();
+            energy += readRule.calculateEnergy(molecule);
+            entropy += readRule.calculateEntropy(molecule);
+        }
+
+        if (this.writeTable != null) {
+            Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
+            if (toWrite != null && writeCharged(context)) {
+                Rule writeRule = writeRuleFor(toWrite);
+                if (writeRule != null) {
+                    energy += writeRule.calculateEnergy(toWrite);
+                    entropy += writeRule.calculateEntropy(toWrite);
+                }
+            }
+        }
+        return new Thermodynamics(energy, entropy);
     }
 
     @Override
     public int getEnergyCost(ThermodynamicContext context) {
-        int total = baseEnergy; // Always start with base energy
-
         ConflictResolutionStatus status = context.instruction().getConflictStatus();
         if (status != ConflictResolutionStatus.WON_EXECUTION && status != ConflictResolutionStatus.NOT_APPLICABLE) {
             // Instruction lost conflict or failed - only return base energy (if any)
-            return total;
+            return baseEnergy;
         }
-
-        // Apply read-rules if targetInfo is present
-        if (context.targetInfo().isPresent() && !readRules.isEmpty()) {
-            var target = context.targetInfo().get();
-            var organism = context.organism();
-
-            Ownership ownership;
-            if (target.ownerId() == organism.getId()) {
-                ownership = Ownership.OWN;
-            } else if (target.ownerId() == 0) {
-                ownership = Ownership.UNOWNED;
-            } else {
-                ownership = Ownership.FOREIGN;
-            }
-
-            Map<Integer, TypeRule> typeRules = readRules.get(ownership);
-            if (typeRules != null) {
-                TypeRule typeRule = typeRules.get(target.molecule().type());
-                if (typeRule == null) {
-                    typeRule = typeRules.get(DEFAULT_TYPE_KEY);
-                }
-
-                if (typeRule != null) {
-                    total += typeRule.resolve(target.molecule()).calculateEnergy(target.molecule());
+        int total = baseEnergy;
+        Rule readRule = readRuleFor(context);
+        if (readRule != null) {
+            total += readRule.calculateEnergy(context.targetInfo().get().molecule());
+        }
+        if (this.writeTable != null) {
+            Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
+            if (toWrite != null && writeCharged(context)) {
+                Rule writeRule = writeRuleFor(toWrite);
+                if (writeRule != null) {
+                    total += writeRule.calculateEnergy(toWrite);
                 }
             }
         }
-
-        // Apply write-rules if a molecule is being written
-        Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
-        if (toWrite != null && !writeRules.isEmpty()) {
-            // Check if target is already occupied (for POKE-like instructions)
-            // Exception: PPK instructions first execute PEEK which clears the cell,
-            // so POKE will always succeed - we should charge the cost even if target appears occupied.
-            String instructionName = context.instruction().getName();
-            boolean isPPK = "PPKR".equals(instructionName) || "PPKI".equals(instructionName) || "PPKS".equals(instructionName);
-
-            if (!isPPK && context.targetInfo().isPresent()) {
-                var target = context.targetInfo().get();
-                if (!target.molecule().isEmpty()) {
-                    // Target is occupied, write will fail - don't add write costs
-                    return total;
-                }
-            }
-
-            TypeRule typeRule = writeRules.get(toWrite.type());
-            if (typeRule == null) {
-                typeRule = writeRules.get(DEFAULT_TYPE_KEY);
-            }
-
-            if (typeRule != null) {
-                total += typeRule.resolve(toWrite).calculateEnergy(toWrite);
-            }
-        }
-
         return total;
     }
 
     @Override
     public int getEntropyDelta(ThermodynamicContext context) {
-        int total = baseEntropy; // Always start with base entropy
-
         ConflictResolutionStatus status = context.instruction().getConflictStatus();
         if (status != ConflictResolutionStatus.WON_EXECUTION && status != ConflictResolutionStatus.NOT_APPLICABLE) {
             // Instruction lost conflict or failed - only return base entropy (if any)
-            return total;
+            return baseEntropy;
         }
-
-        // Apply read-rules if targetInfo is present
-        if (context.targetInfo().isPresent() && !readRules.isEmpty()) {
-            var target = context.targetInfo().get();
-            var organism = context.organism();
-
-            Ownership ownership;
-            if (target.ownerId() == organism.getId()) {
-                ownership = Ownership.OWN;
-            } else if (target.ownerId() == 0) {
-                ownership = Ownership.UNOWNED;
-            } else {
-                ownership = Ownership.FOREIGN;
-            }
-
-            Map<Integer, TypeRule> typeRules = readRules.get(ownership);
-            if (typeRules != null) {
-                TypeRule typeRule = typeRules.get(target.molecule().type());
-                if (typeRule == null) {
-                    typeRule = typeRules.get(DEFAULT_TYPE_KEY);
-                }
-
-                if (typeRule != null) {
-                    total += typeRule.resolve(target.molecule()).calculateEntropy(target.molecule());
+        int total = baseEntropy;
+        Rule readRule = readRuleFor(context);
+        if (readRule != null) {
+            total += readRule.calculateEntropy(context.targetInfo().get().molecule());
+        }
+        if (this.writeTable != null) {
+            Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
+            if (toWrite != null && writeCharged(context)) {
+                Rule writeRule = writeRuleFor(toWrite);
+                if (writeRule != null) {
+                    total += writeRule.calculateEntropy(toWrite);
                 }
             }
         }
-
-        // Apply write-rules if a molecule is being written
-        Molecule toWrite = getMoleculeToWrite(context.resolvedOperands());
-        if (toWrite != null && !writeRules.isEmpty()) {
-            TypeRule typeRule = writeRules.get(toWrite.type());
-            if (typeRule == null) {
-                typeRule = writeRules.get(DEFAULT_TYPE_KEY);
-            }
-
-            if (typeRule != null) {
-                total += typeRule.resolve(toWrite).calculateEntropy(toWrite);
-            }
-        }
-
         return total;
     }
-    
+
     /**
      * Parses a type-level rule from config, including optional value-specific overrides.
      * <p>
@@ -378,4 +445,3 @@ public class UniversalThermodynamicPolicy implements IThermodynamicPolicy {
         return null;
     }
 }
-

--- a/src/test/java/org/evochora/runtime/thermodynamics/impl/PokeThermodynamicPolicyTest.java
+++ b/src/test/java/org/evochora/runtime/thermodynamics/impl/PokeThermodynamicPolicyTest.java
@@ -1,0 +1,82 @@
+package org.evochora.runtime.thermodynamics.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.typesafe.config.ConfigFactory;
+import org.evochora.runtime.Config;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.isa.Instruction.ConflictResolutionStatus;
+import org.evochora.runtime.isa.Instruction.Operand;
+import org.evochora.runtime.model.Molecule;
+import org.evochora.runtime.model.Organism;
+import org.evochora.runtime.spi.thermodynamics.ThermodynamicContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PokeThermodynamicPolicy}, focusing on the rule that a write
+ * onto an occupied target cell fails in execution and therefore carries no write
+ * thermodynamics - neither energy nor entropy.
+ */
+@Tag("unit")
+class PokeThermodynamicPolicyTest {
+
+    private PokeThermodynamicPolicy policy() {
+        var policy = new PokeThermodynamicPolicy();
+        policy.initialize(ConfigFactory.parseString("""
+            CODE: { energy = 5, entropy = -500 }
+            """));
+        return policy;
+    }
+
+    private ThermodynamicContext writeContext(Molecule toWrite, Molecule targetMolecule, String instructionName) {
+        Instruction instruction = mock(Instruction.class);
+        when(instruction.getConflictStatus()).thenReturn(ConflictResolutionStatus.NOT_APPLICABLE);
+        when(instruction.getName()).thenReturn(instructionName);
+
+        Organism organism = mock(Organism.class);
+        when(organism.getId()).thenReturn(1);
+
+        List<Operand> operands = List.of(new Operand(toWrite.toInt(), 0));
+        Optional<ThermodynamicContext.TargetInfo> targetInfo = (targetMolecule == null)
+                ? Optional.empty()
+                : Optional.of(new ThermodynamicContext.TargetInfo(new int[]{0, 0}, targetMolecule, 0));
+        return new ThermodynamicContext(instruction, organism, null, operands, targetInfo);
+    }
+
+    @Test
+    void writeOnEmptyTargetChargesEnergyAndEntropy() {
+        var policy = policy();
+        ThermodynamicContext ctx = writeContext(
+                new Molecule(Config.TYPE_CODE, 42, 0), new Molecule(Config.TYPE_CODE, 0, 0), "POKE");
+        assertThat(policy.getEnergyCost(ctx)).isEqualTo(5);
+        assertThat(policy.getEntropyDelta(ctx)).isEqualTo(-500);
+    }
+
+    @Test
+    void writeOnOccupiedTargetChargesNeitherWriteEnergyNorWriteEntropy() {
+        var policy = policy();
+        // A POKE onto an occupied cell fails in execution and must not book any write
+        // thermodynamics - neither the energy cost nor the entropy dissipation.
+        ThermodynamicContext ctx = writeContext(
+                new Molecule(Config.TYPE_CODE, 42, 0), new Molecule(Config.TYPE_DATA, 7, 0), "POKE");
+        assertThat(policy.getEnergyCost(ctx)).isEqualTo(0);
+        assertThat(policy.getEntropyDelta(ctx)).isEqualTo(0);
+    }
+
+    @Test
+    void ppkWriteOnOccupiedTargetIsStillCharged() {
+        var policy = policy();
+        // PPK instructions peek first, which empties the cell, so their write succeeds
+        // even when the target currently holds a molecule - the write costs apply.
+        ThermodynamicContext ctx = writeContext(
+                new Molecule(Config.TYPE_CODE, 42, 0), new Molecule(Config.TYPE_DATA, 7, 0), "PPKR");
+        assertThat(policy.getEnergyCost(ctx)).isEqualTo(5);
+        assertThat(policy.getEntropyDelta(ctx)).isEqualTo(-500);
+    }
+}

--- a/src/test/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicyTest.java
+++ b/src/test/java/org/evochora/runtime/thermodynamics/impl/UniversalThermodynamicPolicyTest.java
@@ -201,4 +201,67 @@ class UniversalThermodynamicPolicyTest {
         ThermodynamicContext ctx42 = writeContext(new Molecule(Config.TYPE_CODE, 42, 0));
         assertThat(policy.getEnergyCost(ctx42)).isEqualTo(5);
     }
+
+    /**
+     * Creates a ThermodynamicContext for a write whose target cell already holds a molecule.
+     * The instruction's full opcode id is wired to the registry's id for the given name when
+     * the registry is initialized, so the policy's PPK detection works in both modes.
+     */
+    private ThermodynamicContext writeContextWithOccupiedTarget(Molecule toWrite, String instructionName) {
+        Instruction instruction = mock(Instruction.class);
+        when(instruction.getConflictStatus()).thenReturn(ConflictResolutionStatus.NOT_APPLICABLE);
+        when(instruction.getName()).thenReturn(instructionName);
+        Integer opcodeId = Instruction.getInstructionIdByName(instructionName);
+        when(instruction.getFullOpcodeId()).thenReturn(opcodeId != null ? opcodeId : -1);
+
+        Organism organism = mock(Organism.class);
+        when(organism.getId()).thenReturn(1);
+
+        List<Operand> operands = List.of(new Operand(toWrite.toInt(), 0));
+        Molecule occupied = new Molecule(Config.TYPE_DATA, 7, 0);
+        var targetInfo = new ThermodynamicContext.TargetInfo(new int[]{0, 0}, occupied, 0);
+        return new ThermodynamicContext(instruction, organism, null, operands, Optional.of(targetInfo));
+    }
+
+    @Test
+    void writeOnOccupiedTargetChargesNeitherWriteEnergyNorWriteEntropy() {
+        var policy = new UniversalThermodynamicPolicy();
+        policy.initialize(ConfigFactory.parseString("""
+            base-energy = 0
+            base-entropy = 0
+            write-rules: {
+              CODE: { energy = 5, entropy = -500 }
+            }
+            """));
+
+        // A POKE onto an occupied cell fails in execution and must not book any write
+        // thermodynamics - neither the energy cost nor the entropy dissipation.
+        ThermodynamicContext ctx = writeContextWithOccupiedTarget(new Molecule(Config.TYPE_CODE, 42, 0), "POKE");
+        assertThat(policy.getEnergyCost(ctx)).isEqualTo(0);
+        assertThat(policy.getEntropyDelta(ctx)).isEqualTo(0);
+        var combined = policy.getThermodynamics(ctx);
+        assertThat(combined.energyCost()).isEqualTo(0);
+        assertThat(combined.entropyDelta()).isEqualTo(0);
+    }
+
+    @Test
+    void ppkWriteOnOccupiedTargetIsStillCharged() {
+        var policy = new UniversalThermodynamicPolicy();
+        policy.initialize(ConfigFactory.parseString("""
+            base-energy = 0
+            base-entropy = 0
+            write-rules: {
+              CODE: { energy = 5, entropy = -500 }
+            }
+            """));
+
+        // PPK instructions peek first, which empties the cell, so their write succeeds
+        // even when the target currently holds a molecule - the write costs apply.
+        ThermodynamicContext ctx = writeContextWithOccupiedTarget(new Molecule(Config.TYPE_CODE, 42, 0), "PPKR");
+        assertThat(policy.getEnergyCost(ctx)).isEqualTo(5);
+        assertThat(policy.getEntropyDelta(ctx)).isEqualTo(-500);
+        var combined = policy.getThermodynamics(ctx);
+        assertThat(combined.energyCost()).isEqualTo(5);
+        assertThat(combined.entropyDelta()).isEqualTo(-500);
+    }
 }


### PR DESCRIPTION
Two changes to `UniversalThermodynamicPolicy`, which runs for every executed instruction and is on the simulation's hot path.

## 1. Performance refactor (behavior-preserving)

Rule resolution previously walked `Map<Ownership, Map<Integer, TypeRule>>` per instruction with `Integer` autoboxing outside the cache range, ran the complete resolution twice (once for energy, once for entropy), extracted the write molecule (a `Molecule.fromInt` allocation) even for policies without write rules, and identified PPK instructions by three string comparisons.

Now: rules are compiled once in `initialize()` into `TypeRule[ownership][256]` / `TypeRule[256]` slot tables (type-level defaults pre-filled), `getThermodynamics` resolves the context once for both results, the write molecule is only extracted when write rules exist, and PPK detection uses cached opcode ids. The configuration format and the resolution order (value override → type rule → `_default`) are unchanged.

## 2. Bugfix: a failed write must not book write thermodynamics

A write onto an occupied cell fails in execution (`POKE: Target cell is not empty`) and pays the error penalty. The energy side already skipped the write cost in this case, but the entropy side did not: the write entropy (−500 in the production config, i.e. entropy *dissipation*) was credited although nothing was written. That made failed POKEs a free entropy valve — ~100 energy penalty bought 500 entropy dissipation with no effect on the world.

Rule now: a write that will fail carries no write thermodynamics at all, only the penalty; PPK instructions still always pay, because their preceding PEEK empties the cell. Covered by `writeOnOccupiedTargetChargesNeitherWriteEnergyNorWriteEntropy` (written first, red on the old behavior) and `ppkWriteOnOccupiedTargetIsStillCharged`.

## Evidence

- Refactor alone verified behavior-preserving: 10M-tick real-simulation runs (production config, seed 42) produce a bit-identical chunk-stream fingerprint vs. unmodified `main`, on x86 (6 threads) and on the ARM benchmark host (4 threads).
- Performance: thermodynamics' share of tick CPU drops from 6.8 % to 1.85 % (async-profiler, 10M-tick run, ~100 organisms); wall time on the quiet benchmark host 559 s → 545 s for 10M ticks (base run history 551/548/559 s, run-to-run spread < 1 %).
- Bugfix verified live: with the fix, two 10M-tick runs are bit-identical to each other and differ from the pre-fix fingerprint; at tick 10M the population is 125 alive / 2062 created vs. 100 / 2027 before — the valve measurably influenced the dynamics.
- Full test suite, `UniversalThermodynamicPolicyTest`, and the five CLI compile checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtbAp14aBfxyxmyUx47QM9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected energy and entropy calculations when writing to occupied cells.
  * Non-PPK writes to occupied targets no longer incur write costs.
  * PPKR writes continue to apply the appropriate energy and entropy charges.

* **Improvements**
  * Streamlined thermodynamic calculations for more consistent and efficient energy and entropy results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->