### PR TITLE
Read each instruction's argument cells once

### DIFF
--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -123,8 +123,8 @@ public class VirtualMachine {
             int[] rawArgs = null;
             Map<Integer, Object> registerValuesBefore = null;
             if (!lostConflict) {
-                // The argument cells were read when the operands were resolved; the record
-                // reuses that array instead of walking the same cells again.
+                // Shares the array resolveOperands filled: an instruction's argument
+                // cells are read once, and every consumer works from that one read.
                 rawArgs = instruction.getRawArguments();
                 // Collect register values BEFORE execution (for annotation display)
                 registerValuesBefore = collectRegisterValues(organism, instruction.getFullOpcodeId(), rawArgs);

--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -110,14 +110,6 @@ public class VirtualMachine {
             // record, so the argument and register capture below is skipped for it.
             boolean lostConflict = instruction.getConflictStatus() == Instruction.ConflictResolutionStatus.LOST_PRIORITY;
 
-            int[] rawArgs = null;
-            Map<Integer, Object> registerValuesBefore = null;
-            if (!lostConflict) {
-                rawArgs = organism.getRawArgumentsFromEnvironment(instruction.getLength(this.environment), this.environment);
-                // Collect register values BEFORE execution (for annotation display)
-                registerValuesBefore = collectRegisterValues(organism, instruction.getFullOpcodeId(), rawArgs);
-            }
-
             // Track energy and entropy before execution to calculate total changes
             int energyBefore = organism.getEr();
             int entropyBefore = organism.getSr();
@@ -127,6 +119,16 @@ public class VirtualMachine {
             // 1. Resolve operands (idempotent - can be called multiple times safely)
             // Note: resolveOperands only PEEKs stack values, actual POPs happen in commitStackReads()
             List<Instruction.Operand> resolvedOperands = instruction.resolveOperands(this.environment);
+
+            int[] rawArgs = null;
+            Map<Integer, Object> registerValuesBefore = null;
+            if (!lostConflict) {
+                // The argument cells were read when the operands were resolved; the record
+                // reuses that array instead of walking the same cells again.
+                rawArgs = instruction.getRawArguments();
+                // Collect register values BEFORE execution (for annotation display)
+                registerValuesBefore = collectRegisterValues(organism, instruction.getFullOpcodeId(), rawArgs);
+            }
 
             // 2. Commit the stack reads now that we know this instruction will execute. A conflict
             //    loser consumes nothing: it retries with the same operands next tick.

--- a/src/main/java/org/evochora/runtime/isa/Instruction.java
+++ b/src/main/java/org/evochora/runtime/isa/Instruction.java
@@ -216,9 +216,9 @@ public abstract class Instruction {
             return this.cachedOperands;
         }
 
-        // Every argument cell is fetched from the environment exactly once, here. Operand
-        // resolution below and the execution record both work from this array, so no consumer
-        // has to walk the same cells a second time.
+        // The argument cells are fetched here, once per instruction. Operand resolution
+        // below and the execution record both work from this array; nothing else reads the
+        // code stream on their behalf.
         this.rawArguments = organism.getRawArgumentsFromEnvironment(getLength(environment), environment);
 
         List<Operand> resolved = new ArrayList<>(sources.size());

--- a/src/main/java/org/evochora/runtime/isa/Instruction.java
+++ b/src/main/java/org/evochora/runtime/isa/Instruction.java
@@ -95,6 +95,9 @@ public abstract class Instruction {
     private static String[] NAMES_ARRAY = new String[0];
     private static InstructionSignature[] SIGNATURES_ARRAY = new InstructionSignature[0];
 
+    /** Shared empty array for instructions whose opcode carries no arguments. */
+    private static final int[] EMPTY_RAW_ARGUMENTS = new int[0];
+
     /**
      * Whether {@link #init()} has registered the instruction set.
      * <p>
@@ -208,40 +211,23 @@ public abstract class Instruction {
                 ? OPERAND_SOURCES_ARRAY[fullOpcodeId]
                 : OPERAND_SOURCES.get(fullOpcodeId);
         if (sources == null) {
+            this.rawArguments = EMPTY_RAW_ARGUMENTS;
             this.cachedOperands = List.of();
             return this.cachedOperands;
         }
 
+        // Every argument cell is fetched from the environment exactly once, here. Operand
+        // resolution below and the execution record both work from this array, so no consumer
+        // has to walk the same cells a second time.
+        this.rawArguments = organism.getRawArgumentsFromEnvironment(getLength(environment), environment);
+
         List<Operand> resolved = new ArrayList<>(sources.size());
-        org.evochora.runtime.model.EnvironmentProperties props = environment.properties;
-        int dims = props.getDimensions();
-
-        // Setup flat-index tracking (DV is a unit vector: exactly one component is ±1)
-        int[] ipBefore = organism.getIpBeforeFetch();
-        int[] dvBefore = organism.getDvBeforeFetch();
-        int dim = 0;
-        int sign = 1;
-        for (int i = 0; i < dvBefore.length; i++) {
-            if (dvBefore[i] != 0) {
-                dim = i;
-                sign = dvBefore[i];
-                break;
-            }
-        }
-        int dimStride = props.getStride(dim);
-        int dimSize = props.getDimensionSize(dim);
-        boolean isToroidal = props.isToroidal();
-        int dimPos = ipBefore[dim];
-
-        int flatIp = 0;
-        for (int i = 0; i < ipBefore.length; i++) {
-            flatIp += ipBefore[i] * props.getStride(i);
-        }
-        int baseFlatIp = flatIp - dimPos * dimStride;
+        int dims = environment.properties.getDimensions();
 
         // For STACK operands: use iterator to peek without popping
         Iterator<Object> stackIterator = organism.getDataStack().iterator();
 
+        int slot = 0;
         for (OperandSource source : sources) {
             if (source == OperandSource.STACK) {
                 // PEEK via iterator - no side effects!
@@ -255,15 +241,8 @@ public abstract class Instruction {
                 continue;
             }
 
-            // Advance one step along DV
-            dimPos += sign;
-            if (isToroidal) {
-                if (dimPos < 0) dimPos = dimSize - 1;
-                else if (dimPos >= dimSize) dimPos = 0;
-            }
-            int rawMol = (dimPos >= 0 && dimPos < dimSize)
-                    ? environment.getMoleculeInt(baseFlatIp + dimPos * dimStride)
-                    : 0;
+            // Every remaining source occupies one argument slot; VECTOR takes one per dimension.
+            int rawMol = this.rawArguments[slot++];
 
             switch (source) {
                 case REGISTER -> {
@@ -281,15 +260,7 @@ public abstract class Instruction {
                     int[] vec = new int[dims];
                     vec[0] = Molecule.extractSignedValue(rawMol);
                     for (int d = 1; d < dims; d++) {
-                        dimPos += sign;
-                        if (isToroidal) {
-                            if (dimPos < 0) dimPos = dimSize - 1;
-                            else if (dimPos >= dimSize) dimPos = 0;
-                        }
-                        rawMol = (dimPos >= 0 && dimPos < dimSize)
-                                ? environment.getMoleculeInt(baseFlatIp + dimPos * dimStride)
-                                : 0;
-                        vec[d] = Molecule.extractSignedValue(rawMol);
+                        vec[d] = Molecule.extractSignedValue(this.rawArguments[slot++]);
                     }
                     resolved.add(new Operand(vec, -1));
                 }
@@ -318,6 +289,25 @@ public abstract class Instruction {
         for (int i = 0; i < this.stackPeekCount; i++) {
             organism.getDataStack().pop();
         }
+    }
+
+    /**
+     * Returns the raw molecule values of this instruction's argument slots, in the order they
+     * occupy the code stream.
+     * <p>
+     * The array is filled by {@link #resolveOperands(Environment)} and must not be modified: it is
+     * the same array the operand resolution read from, and it is handed on to the execution record
+     * without a copy.
+     *
+     * @return the argument slots, empty for an instruction without arguments
+     * @throws IllegalStateException if the operands of this instruction have not been resolved yet
+     */
+    public int[] getRawArguments() {
+        if (this.rawArguments == null) {
+            throw new IllegalStateException(
+                    "Raw arguments requested before resolveOperands() ran for opcode " + fullOpcodeId);
+        }
+        return this.rawArguments;
     }
 
     // ========== Fuzzy Jump Helper Methods ==========
@@ -783,6 +773,9 @@ public abstract class Instruction {
     
     /** Cached operands - resolved once, returned on subsequent calls (idempotent). */
     private List<Operand> cachedOperands = null;
+
+    /** Argument slots as read from the environment, filled by {@link #resolveOperands(Environment)}. */
+    private int[] rawArguments = null;
 
     /** Number of stack values that were peeked during resolveOperands() and need to be popped in commitStackReads(). */
     private int stackPeekCount = 0;

--- a/src/test/java/org/evochora/runtime/isa/InstructionArgumentSlotTest.java
+++ b/src/test/java/org/evochora/runtime/isa/InstructionArgumentSlotTest.java
@@ -1,0 +1,97 @@
+package org.evochora.runtime.isa;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.evochora.runtime.Config;
+import org.evochora.runtime.Simulation;
+import org.evochora.runtime.model.Environment;
+import org.evochora.runtime.model.Molecule;
+import org.evochora.runtime.model.Organism;
+import org.evochora.test.utils.SimulationTestUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that an instruction's argument slots are mapped to its operands by position.
+ * <p>
+ * A vector operand occupies one slot per dimension while every other operand occupies exactly one,
+ * so an operand that follows a vector sits at a position that depends on the dimensionality of the
+ * world. {@code FRKI} is the only opcode in the instruction set whose arguments continue after a
+ * vector, which makes it the case where a miscounted slot would surface — as a value read from the
+ * wrong cell rather than as an error.
+ */
+public class InstructionArgumentSlotTest {
+
+    @BeforeAll
+    static void init() {
+        Instruction.init();
+    }
+
+    /**
+     * Places an instruction and its arguments as raw molecules along the organism's direction
+     * vector, starting at its instruction pointer.
+     */
+    private static void placeInstruction(Environment environment, Organism organism,
+                                         String name, int... argumentValues) {
+        int opcode = Instruction.getInstructionIdByName(name);
+        environment.setMolecule(new Molecule(Config.TYPE_CODE, opcode), organism.getIp());
+        int[] position = organism.getIp();
+        for (int value : argumentValues) {
+            position = organism.getNextInstructionPosition(position, organism.getDv(), environment);
+            environment.setMolecule(new Molecule(Config.TYPE_DATA, value), position);
+        }
+    }
+
+    @ParameterizedTest(name = "{0} dimensions")
+    @ValueSource(ints = {2, 3, 4, 5})
+    @Tag("unit")
+    void vectorArgumentsDoNotDisplaceTheOperandsThatFollowThem(int dimensions) {
+        int[] shape = new int[dimensions];
+        Arrays.fill(shape, 32);
+        Environment environment = new Environment(shape, true);
+        Simulation simulation = SimulationTestUtils.createSimulation(environment);
+
+        int[] start = new int[dimensions];
+        Arrays.fill(start, 4);
+        Organism organism = Organism.create(simulation, start, 5000);
+        simulation.addOrganism(organism);
+
+        // Every argument carries a different value, so a slot read from the wrong position
+        // produces a wrong value rather than an accidentally matching one.
+        int[] firstVector = new int[dimensions];
+        int[] secondVector = new int[dimensions];
+        for (int d = 0; d < dimensions; d++) {
+            firstVector[d] = 11 + d;
+            secondVector[d] = 71 + d;
+        }
+        int childEnergy = 500;
+
+        int[] arguments = new int[2 * dimensions + 1];
+        System.arraycopy(firstVector, 0, arguments, 0, dimensions);
+        arguments[dimensions] = childEnergy;
+        System.arraycopy(secondVector, 0, arguments, dimensions + 1, dimensions);
+        placeInstruction(environment, organism, "FRKI", arguments);
+
+        Instruction planned = simulation.getVirtualMachine().plan(organism);
+        List<Instruction.Operand> operands = planned.resolveOperands(environment);
+
+        // The raw slots are the code stream as written, one entry per cell.
+        int[] expectedRaw = new int[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            expectedRaw[i] = new Molecule(Config.TYPE_DATA, arguments[i]).toInt();
+        }
+        assertThat(planned.getRawArguments()).containsExactly(expectedRaw);
+
+        // FRKI is declared as VECTOR, IMMEDIATE, VECTOR: three operands, whatever the dimensionality.
+        assertThat(operands).hasSize(3);
+        assertThat(operands.get(0).value()).isEqualTo(firstVector);
+        assertThat(operands.get(1).value())
+                .isEqualTo(new Molecule(Config.TYPE_DATA, childEnergy).toInt());
+        assertThat(operands.get(2).value()).isEqualTo(secondVector);
+    }
+}


### PR DESCRIPTION
## What this changes

Operand resolution and the execution record both walked the code stream to read the same argument cells. `Instruction.resolveOperands` now fetches the argument slots once — through `Organism.getRawArgumentsFromEnvironment`, the same method the record used — keeps the array, and interprets the operands from it. `VirtualMachine.execute` takes the array from the instruction instead of walking the grid a second time.

Two side effects fall out of the move:

- The resolution no longer copies the organism's pre-fetch IP and DV. It used the copying getters (`Organism.getIpBeforeFetch()`, `getDvBeforeFetch()`) only to run its own grid walk; the method it now calls uses the fields directly.
- The flat-index arithmetic exists once instead of twice.

## Why

On a production grid the argument cells sit far outside the last-level cache, so the second walk is paid in cache misses — on every instruction of every organism in every tick.

## Measurement

Dedicated benchmark host, real simulation, 10M ticks, `parallelism=4`, two rounds with the order of the variants swapped. Both trees were identical except for `evochora-latest.jar` (verified by checksum over all 98 library files).

| Round | Order | base | this branch |
|---|---|---|---|
| 1 | base → change | 549 s | 520 s |
| 2 | change → base | 551 s | 529 s |
| **Mean** | | **550 s** | **524.5 s** (−4.6 %) |

The base side reproduces to 0.4 % across both rounds and matches earlier measurements of the same commit on this host (548/551/559 s). The change wins in both orders, so the result is not an artefact of measurement order.

**Behaviour neutrality:** the tick hash is `0bcdf64c641bdba3` in all four runs, with identical organism counts (100 alive, 2027 created) after ten million ticks with mutation plugins active.

## What the measurement does not cover

The hash covers only the instructions the primordial program uses. Of the instructions with VECTOR arguments — the part where the slot arithmetic was rewritten — it exercises `PPKI` and `SEKI`, in both of which the vector is the **last** argument. `FRKI` (`VECTOR, IMMEDIATE, VECTOR`) is the only instruction in the ISA where arguments follow a vector; it is covered by unit tests, not by the measured run.

Instructions never mix stack operands with code arguments, so the early return in `resolveOperands` for an exhausted data stack cannot desynchronise the slot arithmetic: those instructions carry no argument slots at all.

## Tests

Full suite green: 2325 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xceL1HuBDDxYLkA1BB3cE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction argument handling to ensure operands are read from the correct positions.
  * Preserved accurate register state and conflict handling during execution.

* **Tests**
  * Added coverage for vector and immediate operand combinations across worlds with different dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->