### PR TITLE
Observation capture is sampling-gated: the register map is collected only on sampled ticks

### DIFF
--- a/src/main/java/org/evochora/datapipeline/services/SimulationEngine.java
+++ b/src/main/java/org/evochora/datapipeline/services/SimulationEngine.java
@@ -540,6 +540,9 @@ public class SimulationEngine extends AbstractService implements IMemoryEstimata
                     && !isStopRequested() && !Thread.currentThread().isInterrupted()) {
                 checkPause();
 
+                // Per-instruction execution details are only consumed when the tick that is
+                // about to run gets sampled afterwards; all other ticks skip the capture.
+                simulation.setCaptureExecutionDetails((currentTick.get() + 1) % samplingInterval == 0);
                 simulation.tick();
                 long tick = currentTick.incrementAndGet();
 

--- a/src/main/java/org/evochora/runtime/Simulation.java
+++ b/src/main/java/org/evochora/runtime/Simulation.java
@@ -64,11 +64,13 @@ public class Simulation {
     private int organismsSinceYield = 0;
 
     /**
-     * When set, the virtual machine records each executed instruction's raw arguments and
-     * pre-execution register values on the organism. This capture exists solely for
-     * observers of sampled ticks (state serialization reads it, nothing else does); on
-     * every other tick it would cost a map of boxed register values per instruction for
-     * nothing. Defaults to on, so callers that never sample keep the full record.
+     * When set, the virtual machine collects each executed instruction's pre-execution
+     * register values into its execution record. Only this map hangs on the flag — the
+     * record itself (opcode, raw arguments, energy cost, entropy delta) is kept on every
+     * tick. The map exists solely for observers of sampled ticks (state serialization
+     * reads it, nothing else does); on every other tick it would cost a map of boxed
+     * register values per instruction for nothing. Defaults to on, so callers that never
+     * sample keep the full annotation.
      */
     private boolean captureExecutionDetails = true;
     private final LongOpenHashSet allGenomesEverSeen = new LongOpenHashSet();
@@ -201,23 +203,24 @@ public class Simulation {
     }
 
     /**
-     * Chooses whether the next ticks record per-instruction execution details (raw
-     * arguments and pre-execution register values) on the organisms. Samplers enable
-     * this for the tick they are about to capture and disable it otherwise.
+     * Chooses whether the next ticks collect each instruction's pre-execution register
+     * values into its execution record. The record itself (opcode, raw arguments, costs)
+     * is kept regardless of this flag. Samplers enable this for the tick they are about
+     * to capture and disable it otherwise.
      * <p>
      * Must be called between ticks, never while a tick runs: the flag is read from
      * every thread of the parallel wave.
      *
-     * @param capture whether executed instructions leave an execution record
+     * @param capture whether execution records carry pre-execution register values
      */
     public void setCaptureExecutionDetails(boolean capture) {
         this.captureExecutionDetails = capture;
     }
 
     /**
-     * Reports whether executed instructions currently leave an execution record.
+     * Reports whether execution records currently carry pre-execution register values.
      *
-     * @return {@code true} when execution details are recorded
+     * @return {@code true} when register values are collected
      */
     public boolean isCaptureExecutionDetails() {
         return this.captureExecutionDetails;

--- a/src/main/java/org/evochora/runtime/Simulation.java
+++ b/src/main/java/org/evochora/runtime/Simulation.java
@@ -209,7 +209,9 @@ public class Simulation {
      * to capture and disable it otherwise.
      * <p>
      * Must be called between ticks, never while a tick runs: the flag is read from
-     * every thread of the parallel wave.
+     * every thread of the parallel wave. It is deliberately not volatile — visibility
+     * comes from the happens-before edge of handing the tick's work to the worker pool,
+     * the same pattern the class's other plain mutable fields rely on.
      *
      * @param capture whether execution records carry pre-execution register values
      */

--- a/src/main/java/org/evochora/runtime/Simulation.java
+++ b/src/main/java/org/evochora/runtime/Simulation.java
@@ -62,6 +62,15 @@ public class Simulation {
     private int[] scalingMaxThreads = {};
     private int nextOrganismId = 1;
     private int organismsSinceYield = 0;
+
+    /**
+     * When set, the virtual machine records each executed instruction's raw arguments and
+     * pre-execution register values on the organism. This capture exists solely for
+     * observers of sampled ticks (state serialization reads it, nothing else does); on
+     * every other tick it would cost a map of boxed register values per instruction for
+     * nothing. Defaults to on, so callers that never sample keep the full record.
+     */
+    private boolean captureExecutionDetails = true;
     private final LongOpenHashSet allGenomesEverSeen = new LongOpenHashSet();
     private IRandomProvider randomProvider;
 
@@ -189,6 +198,29 @@ public class Simulation {
      */
     public long getTickSeed() {
         return this.tickSeed;
+    }
+
+    /**
+     * Chooses whether the next ticks record per-instruction execution details (raw
+     * arguments and pre-execution register values) on the organisms. Samplers enable
+     * this for the tick they are about to capture and disable it otherwise.
+     * <p>
+     * Must be called between ticks, never while a tick runs: the flag is read from
+     * every thread of the parallel wave.
+     *
+     * @param capture whether executed instructions leave an execution record
+     */
+    public void setCaptureExecutionDetails(boolean capture) {
+        this.captureExecutionDetails = capture;
+    }
+
+    /**
+     * Reports whether executed instructions currently leave an execution record.
+     *
+     * @return {@code true} when execution details are recorded
+     */
+    public boolean isCaptureExecutionDetails() {
+        return this.captureExecutionDetails;
     }
 
     /**

--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -105,27 +105,28 @@ public class VirtualMachine {
             return;
         }
 
-        try {
-            // A conflict loser is booked as a failure but not executed; it leaves no execution
-            // record, so the argument and register capture below is skipped for it.
-            boolean lostConflict = instruction.getConflictStatus() == Instruction.ConflictResolutionStatus.LOST_PRIORITY;
+        // A conflict loser is booked as a failure but not executed; it leaves no execution
+        // record, so the argument and register capture below is skipped for it.
+        boolean lostConflict = instruction.getConflictStatus() == Instruction.ConflictResolutionStatus.LOST_PRIORITY;
 
-            // Track energy and entropy before execution to calculate total changes
-            int energyBefore = organism.getEr();
-            int entropyBefore = organism.getSr();
-            
+        // Track energy and entropy before execution to calculate total changes
+        int energyBefore = organism.getEr();
+        int entropyBefore = organism.getSr();
+
+        // The execution record is consumed only by observers of sampled ticks; the
+        // capture flag spares all other ticks the boxed register map per instruction.
+        boolean captureDetails = !lostConflict && this.simulation.isCaptureExecutionDetails();
+
+        int[] rawArgs = null;
+        Map<Integer, Object> registerValuesBefore = null;
+
+        try {
             // --- Thermodynamic Logic Start ---
 
             // 1. Resolve operands (idempotent - can be called multiple times safely)
             // Note: resolveOperands only PEEKs stack values, actual POPs happen in commitStackReads()
             List<Instruction.Operand> resolvedOperands = instruction.resolveOperands(this.environment);
 
-            // The execution record is consumed only by observers of sampled ticks; the
-            // capture flag spares all other ticks the boxed register map per instruction.
-            boolean captureDetails = !lostConflict && this.simulation.isCaptureExecutionDetails();
-
-            int[] rawArgs = null;
-            Map<Integer, Object> registerValuesBefore = null;
             if (captureDetails) {
                 // Shares the array resolveOperands filled: an instruction's argument
                 // cells are read once, and every consumer works from that one read.
@@ -224,10 +225,22 @@ public class VirtualMachine {
         } catch (Exception e) {
             // Global Catch-All to prevent simulation crash
             organism.instructionFailed("VM Runtime Error: " + e);
-            
+
             // Apply penalty
             int penalty = this.simulation.getOrganismConfig().getInt("error-penalty-cost");
             organism.takeEr(penalty);
+
+            // A throwing instruction still leaves an execution record: what ran and what it
+            // cost (penalty included) stays observable, even if the organism dies of it.
+            if (captureDetails) {
+                organism.setLastInstructionExecution(new Organism.InstructionExecutionData(
+                    instruction.getFullOpcodeId(),
+                    rawArgs,
+                    energyBefore - organism.getEr(),
+                    organism.getSr() - entropyBefore,
+                    registerValuesBefore
+                ));
+            }
 
             if (organism.getEr() <= 0) {
                 organism.kill("Ran out of energy");

--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -114,9 +114,14 @@ public class VirtualMachine {
         int entropyBefore = organism.getSr();
 
         // The register map is consumed only by observers of sampled ticks; the capture
-        // flag spares all other ticks its per-instruction boxing. The rest of the record
-        // is kept every tick, so an organism dying between two samples still shows the
-        // instruction it died of.
+        // flag spares all other ticks its per-instruction boxing (signature lookup,
+        // register reads, boxed map). The rest of the record is kept every tick, so an
+        // organism dying between two samples still shows the instruction it died of —
+        // deliberately without its register values, which were not collected on that
+        // tick. This gap could be closed without per-tick boxing by copying the argument
+        // register values into a reusable per-organism buffer on every tick and building
+        // the map only on sampled ticks and on death, at the price of the per-tick
+        // signature lookup, register reads and copies.
         boolean captureRegisterValues = !lostConflict && this.simulation.isCaptureExecutionDetails();
 
         int[] rawArgs = null;

--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -120,9 +120,13 @@ public class VirtualMachine {
             // Note: resolveOperands only PEEKs stack values, actual POPs happen in commitStackReads()
             List<Instruction.Operand> resolvedOperands = instruction.resolveOperands(this.environment);
 
+            // The execution record is consumed only by observers of sampled ticks; the
+            // capture flag spares all other ticks the boxed register map per instruction.
+            boolean captureDetails = !lostConflict && this.simulation.isCaptureExecutionDetails();
+
             int[] rawArgs = null;
             Map<Integer, Object> registerValuesBefore = null;
-            if (!lostConflict) {
+            if (captureDetails) {
                 // Shares the array resolveOperands filled: an instruction's argument
                 // cells are read once, and every consumer works from that one read.
                 rawArgs = instruction.getRawArguments();
@@ -193,7 +197,7 @@ public class VirtualMachine {
 
             // Store instruction execution data for history tracking. A conflict loser was not
             // executed, so it leaves no execution record; its failure reason is the trace.
-            if (!lostConflict) {
+            if (captureDetails) {
                 Organism.InstructionExecutionData executionData = new Organism.InstructionExecutionData(
                     instruction.getFullOpcodeId(),
                     rawArgs,

--- a/src/main/java/org/evochora/runtime/VirtualMachine.java
+++ b/src/main/java/org/evochora/runtime/VirtualMachine.java
@@ -113,9 +113,11 @@ public class VirtualMachine {
         int energyBefore = organism.getEr();
         int entropyBefore = organism.getSr();
 
-        // The execution record is consumed only by observers of sampled ticks; the
-        // capture flag spares all other ticks the boxed register map per instruction.
-        boolean captureDetails = !lostConflict && this.simulation.isCaptureExecutionDetails();
+        // The register map is consumed only by observers of sampled ticks; the capture
+        // flag spares all other ticks its per-instruction boxing. The rest of the record
+        // is kept every tick, so an organism dying between two samples still shows the
+        // instruction it died of.
+        boolean captureRegisterValues = !lostConflict && this.simulation.isCaptureExecutionDetails();
 
         int[] rawArgs = null;
         Map<Integer, Object> registerValuesBefore = null;
@@ -127,10 +129,12 @@ public class VirtualMachine {
             // Note: resolveOperands only PEEKs stack values, actual POPs happen in commitStackReads()
             List<Instruction.Operand> resolvedOperands = instruction.resolveOperands(this.environment);
 
-            if (captureDetails) {
+            if (!lostConflict) {
                 // Shares the array resolveOperands filled: an instruction's argument
                 // cells are read once, and every consumer works from that one read.
                 rawArgs = instruction.getRawArguments();
+            }
+            if (captureRegisterValues) {
                 // Collect register values BEFORE execution (for annotation display)
                 registerValuesBefore = collectRegisterValues(organism, instruction.getFullOpcodeId(), rawArgs);
             }
@@ -198,7 +202,7 @@ public class VirtualMachine {
 
             // Store instruction execution data for history tracking. A conflict loser was not
             // executed, so it leaves no execution record; its failure reason is the trace.
-            if (captureDetails) {
+            if (!lostConflict) {
                 Organism.InstructionExecutionData executionData = new Organism.InstructionExecutionData(
                     instruction.getFullOpcodeId(),
                     rawArgs,
@@ -232,7 +236,7 @@ public class VirtualMachine {
 
             // A throwing instruction still leaves an execution record: what ran and what it
             // cost (penalty included) stays observable, even if the organism dies of it.
-            if (captureDetails) {
+            if (!lostConflict) {
                 organism.setLastInstructionExecution(new Organism.InstructionExecutionData(
                     instruction.getFullOpcodeId(),
                     rawArgs,

--- a/src/main/java/org/evochora/runtime/isa/Instruction.java
+++ b/src/main/java/org/evochora/runtime/isa/Instruction.java
@@ -254,6 +254,12 @@ public abstract class Instruction {
                 }
                 case LOCATION_REGISTER -> {
                     int regId = Molecule.extractSignedValue(rawMol);
+                    // Probes the id exactly like the REGISTER branch: an invalid id marks the
+                    // instruction failed during planning, so later readers of register values
+                    // (the instruction body, observers) find the failure already recorded and
+                    // never produce it themselves. The operand carries only the id, because
+                    // location registers are read and written by the instruction itself.
+                    organism.readOperand(regId);
                     resolved.add(new Operand(null, regId));
                 }
                 case VECTOR -> {

--- a/src/main/java/org/evochora/runtime/model/Organism.java
+++ b/src/main/java/org/evochora/runtime/model/Organism.java
@@ -49,7 +49,10 @@ public class Organism {
      * @param energyCost The total energy cost for executing this instruction.
      * @param registerValuesBefore Register values before instruction execution (for annotation display).
      *                             Maps register ID to register value (only for registers used as arguments).
-     *                             Can be empty but never null.
+     *                             {@code null} means the values were not collected: they are gathered
+     *                             only on sampled ticks, so the frozen record of an organism that died
+     *                             between two samples carries none. An empty map means the values were
+     *                             collected but the instruction had no register arguments.
      */
     public record InstructionExecutionData(
         int opcodeId,

--- a/src/main/proto/org/evochora/datapipeline/api/contracts/tickdata_contracts.proto
+++ b/src/main/proto/org/evochora/datapipeline/api/contracts/tickdata_contracts.proto
@@ -217,7 +217,10 @@ message OrganismState {
   // Maps register ID to RegisterValue (only for registers used as arguments)
   // Key: register ID (int32), Value: RegisterValue
   // Source: InstructionExecutionData.registerValuesBefore
-  // Only present if an instruction was executed in this tick
+  // Only present if an instruction was executed in this tick AND the tick was
+  // sampled: the runtime collects these values only on sampled ticks, so an
+  // organism that died between two samples carries its dying instruction
+  // (opcode, arguments, costs) without these values.
   map<int32, RegisterValue> instruction_register_values_before = 25;
 
   // ===== Special Registers =====
@@ -318,6 +321,8 @@ message OrganismRuntimeState {
   optional int32 instruction_entropy_delta = 11;
   optional Vector instruction_ip_before_fetch = 12;
   optional Vector instruction_dv_before_fetch = 13;
+  // Collected only on sampled ticks: an organism that died between two samples
+  // carries its dying instruction without these values.
   map<int32, RegisterValue> instruction_register_values_before = 14;
 
   // ===== Special Registers =====

--- a/src/test/java/org/evochora/datapipeline/services/SimulationEngineIntegrationTest.java
+++ b/src/test/java/org/evochora/datapipeline/services/SimulationEngineIntegrationTest.java
@@ -289,6 +289,79 @@ class SimulationEngineIntegrationTest {
     }
 
     @Test
+    void engine_collectsRegisterValuesOnSampledTicks() throws InterruptedException, IOException {
+        // A failure-free endless loop of register instructions: the organism survives the
+        // whole run (simple.evo dies of repeated POKI penalties around tick 20), and almost
+        // every sampled tick's last instruction carries register arguments.
+        Path loopProgram = tempDir.resolve("register_loop.evo");
+        Files.writeString(loopProgram, """
+                START:
+                  SETI %DR0 DATA:1
+                  ADDI %DR0 DATA:1
+                  JMPI START
+                """);
+        Config sampledConfig = baseConfig
+                .withValue("samplingInterval", ConfigValueFactory.fromAnyRef(10))
+                .withValue("pauseTicks", ConfigValueFactory.fromAnyRef(List.of(100L)))
+                .withValue("organisms", ConfigValueFactory.fromAnyRef(List.of(Map.of(
+                        "program", loopProgram.toString(),
+                        "initialEnergy", 10000,
+                        "placement", Map.of("positions", List.of(5, 5))
+                ))));
+
+        SimulationEngine engine = new SimulationEngine("test-engine", sampledConfig, resources);
+
+        engine.start();
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(AbstractService.State.PAUSED, engine.getCurrentState()));
+
+        // The engine enables execution-detail capture exactly for the ticks it samples.
+        // The test program executes register instructions on almost every tick, so with
+        // correct wiring the sampled states carry register values; a wiring regression
+        // (flag never set, or set for the wrong tick) yields zero such samples, because
+        // register values are collected only while the flag is on.
+        // counters[0]: sampled states with an organism; counters[1]: those whose organism
+        // carries register values.
+        int[] counters = new int[2];
+        while (true) {
+            try (StreamingBatch<TickDataChunk> batch = tickDataQueue.receiveBatch(100, 100, TimeUnit.MILLISECONDS)) {
+                if (batch.size() == 0) {
+                    break;
+                }
+                for (TickDataChunk chunk : batch) {
+                    if (chunk.hasSnapshot()) {
+                        countSampledState(chunk.getSnapshot().getTickNumber(),
+                                chunk.getSnapshot().getOrganismsList(), counters);
+                    }
+                    for (org.evochora.datapipeline.api.contracts.TickDelta delta : chunk.getDeltasList()) {
+                        countSampledState(delta.getTickNumber(), delta.getOrganismsList(), counters);
+                    }
+                }
+                batch.commit();
+            }
+        }
+        engine.stop();
+        assertEquals(11, counters[0], "ticks 0-100 with interval 10 yield 11 sampled states");
+        assertTrue(counters[1] > 0,
+                "sampled states must carry register values when the capture flag is wired to the sampled ticks");
+    }
+
+    private static void countSampledState(long tickNumber, List<OrganismState> organisms, int[] counters) {
+        if (organisms.isEmpty()) {
+            return;
+        }
+        OrganismState organism = organisms.get(0);
+        counters[0]++;
+        if (tickNumber > 0) {
+            assertTrue(organism.hasInstructionOpcodeId(),
+                    "every sampled state carries the executed instruction");
+        }
+        if (organism.getInstructionRegisterValuesBeforeCount() > 0) {
+            counters[1]++;
+        }
+    }
+
+    @Test
     void engine_shouldNotSampleWithLargeSamplingInterval() {
         Config sampledConfig = baseConfig
                 .withValue("samplingInterval", ConfigValueFactory.fromAnyRef(100))

--- a/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
+++ b/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
@@ -19,8 +19,8 @@ import com.typesafe.config.ConfigFactory;
 
 /**
  * Unit tests for {@link Simulation#setCaptureExecutionDetails(boolean)}: executed
- * instructions leave an execution record on the organism exactly when the capture
- * is enabled, which is the default.
+ * instructions always leave an execution record on the organism; the register-value
+ * annotation is collected exactly when the capture is enabled, which is the default.
  */
 @Tag("unit")
 class CaptureExecutionDetailsTest {
@@ -60,25 +60,31 @@ class CaptureExecutionDetailsTest {
     }
 
     @Test
-    void executionRecordIsPresentByDefault() {
+    void executionRecordWithRegisterValuesIsPresentByDefault() {
         simulation.tick();
-        assertThat(organism.getLastInstructionExecution()).isNotNull();
+        Organism.InstructionExecutionData record = organism.getLastInstructionExecution();
+        assertThat(record).isNotNull();
+        assertThat(record.registerValuesBefore()).isNotNull();
     }
 
     @Test
-    void executionRecordIsSkippedWhenCaptureIsOff() {
+    void registerValuesAreSkippedWhenCaptureIsOff() {
         simulation.setCaptureExecutionDetails(false);
         simulation.tick();
-        assertThat(organism.getLastInstructionExecution()).isNull();
+        Organism.InstructionExecutionData record = organism.getLastInstructionExecution();
+        assertThat(record).isNotNull();
+        assertThat(record.registerValuesBefore()).isNull();
     }
 
     @Test
-    void executionRecordReturnsWhenCaptureIsReEnabled() {
+    void registerValuesReturnWhenCaptureIsReEnabled() {
         simulation.setCaptureExecutionDetails(false);
         simulation.tick();
         simulation.setCaptureExecutionDetails(true);
         simulation.tick();
-        assertThat(organism.getLastInstructionExecution()).isNotNull();
+        Organism.InstructionExecutionData record = organism.getLastInstructionExecution();
+        assertThat(record).isNotNull();
+        assertThat(record.registerValuesBefore()).isNotNull();
     }
 
     /**

--- a/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
+++ b/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
@@ -80,4 +80,40 @@ class CaptureExecutionDetailsTest {
         simulation.tick();
         assertThat(organism.getLastInstructionExecution()).isNotNull();
     }
+
+    /**
+     * Builds an instruction whose execution throws, driving the VM through its
+     * runtime-error path (failure booking, penalty, possible death).
+     */
+    private Instruction throwingInstruction() {
+        int nopOpcode = Instruction.getInstructionIdByName("NOP");
+        return new org.evochora.runtime.isa.instructions.NopInstruction(organism, nopOpcode) {
+            @Override
+            public void execute(org.evochora.runtime.internal.services.ExecutionContext context) {
+                throw new IllegalStateException("test-induced VM failure");
+            }
+        };
+    }
+
+    @Test
+    void executionRecordIsPresentAfterVmRuntimeError() {
+        new VirtualMachine(simulation).execute(throwingInstruction());
+
+        Organism.InstructionExecutionData record = organism.getLastInstructionExecution();
+        assertThat(organism.isInstructionFailed()).isTrue();
+        assertThat(record).isNotNull();
+        assertThat(record.opcodeId()).isEqualTo(Instruction.getInstructionIdByName("NOP"));
+        // Base energy (1) was charged before the throw, the error penalty (10) after it.
+        assertThat(record.energyCost()).isEqualTo(11);
+    }
+
+    @Test
+    void executionRecordIsPresentWhenVmRuntimeErrorKills() {
+        organism.takeEr(organism.getEr() - 5);
+
+        new VirtualMachine(simulation).execute(throwingInstruction());
+
+        assertThat(organism.isDead()).isTrue();
+        assertThat(organism.getLastInstructionExecution()).isNotNull();
+    }
 }

--- a/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
+++ b/src/test/java/org/evochora/runtime/CaptureExecutionDetailsTest.java
@@ -1,0 +1,83 @@
+package org.evochora.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.evochora.runtime.internal.services.SeededRandomProvider;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.Environment;
+import org.evochora.runtime.model.Molecule;
+import org.evochora.runtime.model.Organism;
+import org.evochora.runtime.thermodynamics.ThermodynamicPolicyManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit tests for {@link Simulation#setCaptureExecutionDetails(boolean)}: executed
+ * instructions leave an execution record on the organism exactly when the capture
+ * is enabled, which is the default.
+ */
+@Tag("unit")
+class CaptureExecutionDetailsTest {
+
+    private Simulation simulation;
+    private Organism organism;
+
+    @BeforeAll
+    static void init() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Environment environment = new Environment(new int[]{10, 10}, true);
+        ThermodynamicPolicyManager policyManager = new ThermodynamicPolicyManager(
+            ConfigFactory.parseString("""
+                default {
+                  className = "org.evochora.runtime.thermodynamics.impl.UniversalThermodynamicPolicy"
+                  options { base-energy = 1, base-entropy = 1 }
+                }
+                overrides { instructions {}, families {} }
+                """));
+        com.typesafe.config.Config organismConfig = ConfigFactory.parseMap(Map.of(
+            "max-energy", 32767,
+            "max-entropy", 8191,
+            "error-penalty-cost", 10
+        ));
+
+        simulation = new Simulation(environment, policyManager, organismConfig, 1);
+        simulation.setRandomProvider(new SeededRandomProvider(42L));
+
+        organism = Organism.create(simulation, new int[]{5, 5}, 1000);
+        simulation.addOrganism(organism);
+        int nopOpcode = Instruction.getInstructionIdByName("NOP");
+        environment.setMolecule(new Molecule(Config.TYPE_CODE, nopOpcode), organism.getId(), new int[]{5, 5});
+    }
+
+    @Test
+    void executionRecordIsPresentByDefault() {
+        simulation.tick();
+        assertThat(organism.getLastInstructionExecution()).isNotNull();
+    }
+
+    @Test
+    void executionRecordIsSkippedWhenCaptureIsOff() {
+        simulation.setCaptureExecutionDetails(false);
+        simulation.tick();
+        assertThat(organism.getLastInstructionExecution()).isNull();
+    }
+
+    @Test
+    void executionRecordReturnsWhenCaptureIsReEnabled() {
+        simulation.setCaptureExecutionDetails(false);
+        simulation.tick();
+        simulation.setCaptureExecutionDetails(true);
+        simulation.tick();
+        assertThat(organism.getLastInstructionExecution()).isNotNull();
+    }
+}

--- a/src/test/java/org/evochora/runtime/LocationRegisterPlanValidationTest.java
+++ b/src/test/java/org/evochora/runtime/LocationRegisterPlanValidationTest.java
@@ -1,0 +1,83 @@
+package org.evochora.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.evochora.runtime.internal.services.SeededRandomProvider;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.Environment;
+import org.evochora.runtime.model.Molecule;
+import org.evochora.runtime.model.Organism;
+import org.evochora.runtime.thermodynamics.ThermodynamicPolicyManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Pins the invariant that operand validation happens during planning: an instruction
+ * whose argument cell decodes to an invalid location-register id is marked failed by
+ * {@link VirtualMachine#plan} itself, exactly like an invalid data-register id. Later
+ * readers of register values (the instruction body, observers of sampled ticks) must
+ * find the failure already recorded and never produce it themselves.
+ */
+@Tag("unit")
+class LocationRegisterPlanValidationTest {
+
+    private static final int INVALID_REGISTER_ID = 3000; // beyond the register id table
+
+    private Environment environment;
+    private Simulation simulation;
+    private Organism organism;
+
+    @BeforeAll
+    static void init() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        environment = new Environment(new int[]{10, 10}, true);
+        ThermodynamicPolicyManager policyManager = new ThermodynamicPolicyManager(
+            ConfigFactory.parseString("""
+                default {
+                  className = "org.evochora.runtime.thermodynamics.impl.UniversalThermodynamicPolicy"
+                  options { base-energy = 1, base-entropy = 1 }
+                }
+                overrides { instructions {}, families {} }
+                """));
+        com.typesafe.config.Config organismConfig = ConfigFactory.parseMap(Map.of(
+            "max-energy", 32767,
+            "max-entropy", 8191,
+            "error-penalty-cost", 10
+        ));
+
+        simulation = new Simulation(environment, policyManager, organismConfig, 1);
+        simulation.setRandomProvider(new SeededRandomProvider(42L));
+
+        organism = Organism.create(simulation, new int[]{5, 5}, 1000);
+        simulation.addOrganism(organism);
+
+        // DPLR with an argument cell whose value is not a valid register id
+        int dplrOpcode = Instruction.getInstructionIdByName("DPLR");
+        environment.setMolecule(new Molecule(Config.TYPE_CODE, dplrOpcode), organism.getId(), new int[]{5, 5});
+        environment.setMolecule(new Molecule(Config.TYPE_DATA, INVALID_REGISTER_ID), organism.getId(), new int[]{6, 5});
+    }
+
+    @Test
+    void invalidLocationRegisterIdFailsDuringPlanning() {
+        simulation.getVirtualMachine().plan(organism);
+        assertThat(organism.isInstructionFailed()).isTrue();
+    }
+
+    @Test
+    void failureIsIndependentOfExecutionDetailCapture() {
+        simulation.setCaptureExecutionDetails(false);
+        simulation.tick();
+        boolean failedWithoutCapture = organism.isInstructionFailed();
+        assertThat(failedWithoutCapture).isTrue();
+    }
+}

--- a/src/test/resources/org/evochora/datapipeline/services/simple.evo
+++ b/src/test/resources/org/evochora/datapipeline/services/simple.evo
@@ -34,8 +34,10 @@ LOOP:
   LTI %COUNTER MAX_COUNT
   JMPI LOOP
   
-  # Place result in world
+  # Place result in world, then take it back so the cell is empty again for the
+  # next round: the program stays failure-free no matter how long it runs.
   POKI %RESULT 1|0
-  
+  PEKI %TEMP 1|0
+
   # End program
   JMPI START


### PR DESCRIPTION
## What

The per-instruction register-value map (`instruction_register_values_before`) is the dominant cost of observation capture: a signature lookup, register reads and a boxed map per executed instruction, consumed only by observers of sampled ticks. This PR gates exactly that map behind a per-tick flag the `SimulationEngine` sets before each tick (on for the tick about to be sampled, off otherwise, default on). The cheap record fields (opcode, raw arguments, energy cost, entropy delta) are still kept on every tick, so an organism dying between two samples still shows the instruction it died of.

## Included fixes

- **VM error path books an execution record** (bug also present on main): the record store sat inside the `try`, so a throwing instruction — including one whose penalty kills the organism — left no record. Test-first: two tests were red before the fix.
- **LOCATION_REGISTER ids are probed in the plan phase** like the REGISTER branch, so an invalid id marks the instruction failed during planning instead of depending on the observation path (latent hole, test-first: red before the fix).

## Documented gap

An organism dying between two samples carries its dying instruction **without** register values. Documented at the three consumer surfaces: the `InstructionExecutionData` contract (null = not collected vs. empty = no register arguments), both proto fields, and the capture gate in `VirtualMachine.execute()`. The buffered-capture alternative that closes the gap (measured, bit-identical to main, −2.9 %) is parked as #136.

## Verification

- Full suite + PMD green, all five CLI compile checks pass.
- Local first-divergence forensics (300k ticks, samplingInterval 100, per-chunk protobuf dumps): 300/300 chunks byte-identical to main.
- Demo server, 10M ticks, seed 42, two runs each: main 521/502 s, this branch 467/468 s (**−8.6 %**). Hash deterministic across runs; the difference to main's reference hash `ffa3e288e988845e` was classified field-by-field as exactly the documented gap (missing register values on dead organisms), nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtbAp14aBfxyxmyUx47QM9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable execution-detail capture, allowing register values to be collected only on selected ticks.
  * Reduced processing overhead on ticks that are not sampled.
  * Preserved execution records for instructions that fail during runtime, including energy and entropy changes.

* **Bug Fixes**
  * Invalid location-register references are now detected during instruction planning.
  * Improved tracking for failed instructions and organisms that die during execution.

* **Documentation**
  * Clarified when register values and runtime state are available in sampled data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->