### PR TITLE
Let a call survive linking, and take its address from the layout

### DIFF
--- a/src/main/java/org/evochora/compiler/Compiler.java
+++ b/src/main/java/org/evochora/compiler/Compiler.java
@@ -317,7 +317,7 @@ public class Compiler implements ICompiler {
         Linker linker = new Linker(linkingRegistry, linkingDirRegistry);
         LinkingContext linkContext = new LinkingContext(symbolTable, isa);
         linkContext.pushAliasChain(rootAliasChain);
-        IrProgram linkedIr = linker.link(rewrittenIr, layout, linkContext, envProps);
+        IrProgram linkedIr = linker.link(rewrittenIr, layout, linkContext);
         linkContext.freeze();
 
         // Phase 11: Emission (generate final binary)

--- a/src/main/java/org/evochora/compiler/backend/layout/LayoutEngine.java
+++ b/src/main/java/org/evochora/compiler/backend/layout/LayoutEngine.java
@@ -10,7 +10,9 @@ import org.evochora.compiler.model.ir.IrProgram;
 import org.evochora.compiler.isa.IInstructionSet;
 import org.evochora.runtime.model.EnvironmentProperties;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,9 +34,12 @@ public final class LayoutEngine {
         LayoutContext ctx = new LayoutContext(envProps);
 
         Map<String, Integer> labelToAddress = new HashMap<>();
+        List<PlacedItem> placedItems = new ArrayList<>(program.items().size());
 
         for (IrItem item : program.items()) {
             SourceInfo src = item.source();
+            // Recorded before the item is placed, so it names the item's first cell.
+            placedItems.add(new PlacedItem(item, ctx.linearAddress()));
 
             if (item instanceof IrDirective dir) {
                 registry.resolve(dir).handle(dir, ctx);
@@ -69,6 +74,7 @@ public final class LayoutEngine {
             }
         }
 
-        return new LayoutResult(ctx.linearToCoord(), ctx.coordToLinear(), labelToAddress, ctx.sourceMap(), ctx.initialWorldObjects());
+        return new LayoutResult(ctx.linearToCoord(), ctx.coordToLinear(), labelToAddress, ctx.sourceMap(),
+                ctx.initialWorldObjects(), List.copyOf(placedItems));
     }
 }

--- a/src/main/java/org/evochora/compiler/backend/layout/LayoutResult.java
+++ b/src/main/java/org/evochora/compiler/backend/layout/LayoutResult.java
@@ -3,6 +3,7 @@ package org.evochora.compiler.backend.layout;
 import org.evochora.compiler.api.PlacedMolecule;
 import org.evochora.compiler.api.SourceInfo;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,11 +14,13 @@ import java.util.Map;
  * @param labelToAddress A map from label names to their linear addresses.
  * @param sourceMap A map from linear address to source information.
  * @param initialWorldObjects A map from relative coordinates to molecules that should be placed in the world initially.
+ * @param placedItems The items in the order the layout walked them, each with the address it was given.
  */
 public record LayoutResult(
         Map<Integer, int[]> linearAddressToCoord,
         Map<String, Integer> relativeCoordToLinearAddress,
         Map<String, Integer> labelToAddress,
         Map<Integer, SourceInfo> sourceMap,
-        Map<int[], PlacedMolecule> initialWorldObjects
+        Map<int[], PlacedMolecule> initialWorldObjects,
+        List<PlacedItem> placedItems
 ) {}

--- a/src/main/java/org/evochora/compiler/backend/layout/PlacedItem.java
+++ b/src/main/java/org/evochora/compiler/backend/layout/PlacedItem.java
@@ -1,0 +1,17 @@
+package org.evochora.compiler.backend.layout;
+
+import org.evochora.compiler.model.ir.IrItem;
+
+/**
+ * An IR item together with the linear address the layout assigned to it.
+ * <p>
+ * Addresses are decided in exactly one place, and this is how that decision reaches the phases
+ * that follow. A later phase that recomputed the address instead would have to reproduce how many
+ * cells every kind of item occupies — a rule that would then exist twice and could drift apart.
+ *
+ * @param item The item as it entered the layout phase.
+ * @param linearAddress The address of the item's first cell. Items that occupy no cell — a
+ *                      directive, for instance — carry the address the layout stood at when it
+ *                      reached them.
+ */
+public record PlacedItem(IrItem item, int linearAddress) {}

--- a/src/main/java/org/evochora/compiler/backend/link/Linker.java
+++ b/src/main/java/org/evochora/compiler/backend/link/Linker.java
@@ -2,6 +2,7 @@ package org.evochora.compiler.backend.link;
 
 import org.evochora.compiler.api.CompilationException;
 import org.evochora.compiler.backend.layout.LayoutResult;
+import org.evochora.compiler.backend.layout.PlacedItem;
 import org.evochora.compiler.model.ir.IrDirective;
 import org.evochora.compiler.model.ir.IrInstruction;
 import org.evochora.compiler.model.ir.IrItem;
@@ -42,37 +43,23 @@ public final class Linker {
      */
     public IrProgram link(IrProgram program, LayoutResult layout, LinkingContext context, EnvironmentProperties envProps) throws CompilationException {
         List<IrItem> out = new ArrayList<>();
-        IInstructionSet isa = context.isa();
 
-        for (IrItem item : program.items()) {
+        for (PlacedItem placed : layout.placedItems()) {
+            IrItem item = placed.item();
+
             if (item instanceof IrDirective dir) {
                 directiveRegistry.resolve(dir).handle(dir, context);
             }
 
             if (item instanceof IrInstruction ins) {
+                // The address comes from the layout, which assigned it. Counting along here would
+                // mean deciding a second time how many cells each item occupies.
+                context.setCurrentAddress(placed.linearAddress());
+
                 for (ILinkingRule rule : registry.rules()) {
                     ins = rule.apply(ins, context, layout);
                 }
                 out.add(ins);
-
-                context.nextAddress();
-
-                final IrInstruction linked = ins;
-                int opcodeId = isa.getInstructionIdByName(linked.opcode())
-                        .orElseThrow(() -> new CompilationException("Unknown instruction '" + linked.opcode() + "'.", linked.source()));
-                IInstructionSet.Signature sig = isa.getSignatureById(opcodeId)
-                        .orElseThrow(() -> new CompilationException("No ISA signature for instruction '" + linked.opcode() + "'.", linked.source()));
-                for (IInstructionSet.ArgKind kind : sig.argumentTypes()) {
-                    if (kind == IInstructionSet.ArgKind.VECTOR) {
-                        if (envProps == null || envProps.getWorldShape() == null || envProps.getWorldShape().length == 0) {
-                            throw new CompilationException("Instruction " + ins.opcode() + " requires vector arguments, which need a world context, but no environment properties were provided.", ins.source());
-                        }
-                        int worldDimensions = envProps.getWorldShape().length;
-                        for (int k = 0; k < worldDimensions; k++) context.nextAddress();
-                    } else {
-                        context.nextAddress();
-                    }
-                }
             } else {
                 out.add(item);
             }

--- a/src/main/java/org/evochora/compiler/backend/link/Linker.java
+++ b/src/main/java/org/evochora/compiler/backend/link/Linker.java
@@ -7,8 +7,6 @@ import org.evochora.compiler.model.ir.IrDirective;
 import org.evochora.compiler.model.ir.IrInstruction;
 import org.evochora.compiler.model.ir.IrItem;
 import org.evochora.compiler.model.ir.IrProgram;
-import org.evochora.compiler.isa.IInstructionSet;
-import org.evochora.runtime.model.EnvironmentProperties;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,11 +35,10 @@ public final class Linker {
      * @param program The IR program to link.
      * @param layout The layout result, providing coordinate and address mappings.
      * @param context The linking context, which will be populated with call site bindings.
-     * @param envProps The environment properties, providing context like world dimensions. Can be null.
      * @return The linked IR program.
      * @throws CompilationException if an error occurs during linking.
      */
-    public IrProgram link(IrProgram program, LayoutResult layout, LinkingContext context, EnvironmentProperties envProps) throws CompilationException {
+    public IrProgram link(IrProgram program, LayoutResult layout, LinkingContext context) throws CompilationException {
         List<IrItem> out = new ArrayList<>();
 
         for (PlacedItem placed : layout.placedItems()) {

--- a/src/main/java/org/evochora/compiler/backend/link/LinkingContext.java
+++ b/src/main/java/org/evochora/compiler/backend/link/LinkingContext.java
@@ -45,7 +45,7 @@ public final class LinkingContext {
 
     /**
      * Freezes the context, preventing further modifications.
-     * After freeze: pushAliasChain/popAliasChain/nextAddress throw,
+     * After freeze: pushAliasChain/popAliasChain/setCurrentAddress throw,
      * callSiteBindings returns unmodifiable view.
      */
     public void freeze() {
@@ -62,12 +62,14 @@ public final class LinkingContext {
     }
 
     /**
-     * @return The next linear address and increments the cursor.
+     * Sets the address of the item being linked, as assigned by the layout phase.
+     *
+     * @param linearAddress The address of the item's first cell.
      */
-    public int nextAddress() { guardFrozen(); return linearAddressCursor++; }
+    public void setCurrentAddress(final int linearAddress) { guardFrozen(); this.linearAddressCursor = linearAddress; }
 
     /**
-     * @return The current linear address.
+     * @return The linear address of the item currently being linked.
      */
     public int currentAddress() { return linearAddressCursor; }
 

--- a/src/main/java/org/evochora/compiler/features/label/LabelRefLinkingRule.java
+++ b/src/main/java/org/evochora/compiler/features/label/LabelRefLinkingRule.java
@@ -64,7 +64,7 @@ public class LabelRefLinkingRule implements ILinkingRule {
                 }
             }
         }
-        return rewritten != null ? new IrInstruction(instruction.opcode(), rewritten, instruction.source()) : instruction;
+        return rewritten != null ? instruction.withOperands(rewritten) : instruction;
     }
 
     private String qualifyName(String localName, LinkingContext context) {

--- a/src/main/java/org/evochora/compiler/features/proc/IrCallInstruction.java
+++ b/src/main/java/org/evochora/compiler/features/proc/IrCallInstruction.java
@@ -44,6 +44,19 @@ public final class IrCallInstruction extends IrInstruction {
         this.lvalOperands = Collections.unmodifiableList(lvalOperands);
     }
 
+    /**
+     * Keeps the parameter lists when the main operands are rewritten.
+     * <p>
+     * The procedure name of a call is resolved to a label reference during linking, which replaces
+     * the main operands. Without this, the call would come out of that step as a plain instruction
+     * and the REF/VAL/LREF/LVAL lists would be gone - along with everything that reads them.
+     */
+    @Override
+    public IrCallInstruction withOperands(final List<IrOperand> newOperands) {
+        return new IrCallInstruction(opcode(), newOperands,
+                refOperands, valOperands, lrefOperands, lvalOperands, source());
+    }
+
     /** Scalar reference parameter operands. */
     public List<IrOperand> refOperands() { return refOperands; }
 

--- a/src/main/java/org/evochora/compiler/features/proc/IrCallInstruction.java
+++ b/src/main/java/org/evochora/compiler/features/proc/IrCallInstruction.java
@@ -50,6 +50,9 @@ public final class IrCallInstruction extends IrInstruction {
      * The procedure name of a call is resolved to a label reference during linking, which replaces
      * the main operands. Without this, the call would come out of that step as a plain instruction
      * and the REF/VAL/LREF/LVAL lists would be gone - along with everything that reads them.
+     *
+     * @param newOperands The main operands of the returned call.
+     * @return A call with those main operands and this call's parameter lists.
      */
     @Override
     public IrCallInstruction withOperands(final List<IrOperand> newOperands) {

--- a/src/main/java/org/evochora/compiler/model/ir/IrInstruction.java
+++ b/src/main/java/org/evochora/compiler/model/ir/IrInstruction.java
@@ -78,6 +78,21 @@ public class IrInstruction implements IrItem {
     }
 
     /**
+     * Returns an instruction of the same kind carrying the given main operands.
+     * <p>
+     * Rewriting an operand must not change what an instruction is. Building a plain
+     * {@link IrInstruction} instead would drop whatever a subtype carries beyond the main
+     * operands, and it would do so silently: the result still compiles and still executes, but a
+     * later pass looking for that subtype no longer finds it.
+     *
+     * @param newOperands the main operands of the returned instruction
+     * @return an instruction of this instruction's kind with those operands
+     */
+    public IrInstruction withOperands(final List<IrOperand> newOperands) {
+        return new IrInstruction(opcode(), newOperands, source(), synthetic());
+    }
+
+    /**
      * Returns whether this instruction is synthetic (compiler-generated).
      */
     public boolean synthetic() {

--- a/src/test/java/org/evochora/compiler/backend/link/CallSiteBindingAddressTest.java
+++ b/src/test/java/org/evochora/compiler/backend/link/CallSiteBindingAddressTest.java
@@ -1,0 +1,88 @@
+package org.evochora.compiler.backend.link;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.evochora.compiler.Compiler;
+import org.evochora.compiler.api.ProgramArtifact;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.EnvironmentProperties;
+import org.evochora.runtime.model.Molecule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a call with parameters produces a binding, and that its key names the cell
+ * holding that call.
+ * <p>
+ * The binding is collected from the call's REF/VAL operand lists, which only exist on the call's
+ * own IR type. Anything that rebuilds the instruction as a plain one during linking drops those
+ * lists, and the binding is then never collected - silently, because the result still compiles
+ * and still runs.
+ */
+public class CallSiteBindingAddressTest {
+
+    @BeforeAll
+    static void init() {
+        Instruction.init();
+    }
+
+    @Test
+    @Tag("unit")
+    void bindingKeyNamesTheCallWithoutAPrecedingLabel() throws Exception {
+        assertBindingKeysPointAtCalls(compile(String.join("\n",
+                "SETI %DR0 DATA:29",
+                "CALL INC REF %DR0",
+                "WAIT",
+                ".ORG 0|1",
+                "EXPORT .PROC INC REF A",
+                "  ADDI A DATA:1",
+                "  RET",
+                ".ENDP")));
+    }
+
+    private static ProgramArtifact compile(String source) throws Exception {
+        return new Compiler().compile(
+                Arrays.asList(source.split("\\r?\\n")), "callsite.s",
+                new EnvironmentProperties(new int[]{64, 64}, true));
+    }
+
+    private static void assertBindingKeysPointAtCalls(ProgramArtifact artifact) {
+        int callOpcode = Instruction.getInstructionIdByName("CALL");
+        assertThat(artifact.callSiteBindings())
+                .as("the program has a call site with bindings")
+                .hasSize(1);
+
+        for (Map.Entry<Integer, Map<Integer, Integer>> binding : artifact.callSiteBindings().entrySet()) {
+            int linearAddress = binding.getKey();
+            int[] coord = artifact.linearAddressToCoord().get(linearAddress);
+            assertThat(coord)
+                    .as("linear address %d of a call site binding is a known address", linearAddress)
+                    .isNotNull();
+
+            Integer moleculeValue = machineCodeAt(artifact, coord);
+            assertThat(moleculeValue)
+                    .as("linear address %d points at an emitted cell", linearAddress)
+                    .isNotNull();
+            assertThat(Molecule.fromInt(moleculeValue).toScalarValue())
+                    .as("linear address %d holds the CALL its bindings belong to", linearAddress)
+                    .isEqualTo(callOpcode);
+        }
+    }
+
+    /**
+     * Reads the emitted molecule at a relative coordinate; the layout is keyed by array instances,
+     * so the lookup compares contents.
+     */
+    private static Integer machineCodeAt(ProgramArtifact artifact, int[] coord) {
+        for (Map.Entry<int[], Integer> entry : artifact.machineCodeLayout().entrySet()) {
+            if (Arrays.equals(entry.getKey(), coord)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/evochora/compiler/backend/link/CallSiteBindingAddressTest.java
+++ b/src/test/java/org/evochora/compiler/backend/link/CallSiteBindingAddressTest.java
@@ -15,13 +15,14 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies that a call with parameters produces a binding, and that its key names the cell
- * holding that call.
+ * Verifies that the keys of {@code callSiteBindings} name the cell that holds the CALL they
+ * belong to.
  * <p>
- * The binding is collected from the call's REF/VAL operand lists, which only exist on the call's
- * own IR type. Anything that rebuilds the instruction as a plain one during linking drops those
- * lists, and the binding is then never collected - silently, because the result still compiles
- * and still runs.
+ * The key is a linear address, and the artifact carries a second mapping from linear addresses to
+ * coordinates. Following a key through that mapping has to arrive at a CALL opcode, which requires
+ * both sides to count addresses the same way. A label makes any disagreement visible: it occupies
+ * a cell in the emitted program, so a count that covers only instructions falls behind at the
+ * first one.
  */
 public class CallSiteBindingAddressTest {
 
@@ -42,6 +43,56 @@ public class CallSiteBindingAddressTest {
                 "  ADDI A DATA:1",
                 "  RET",
                 ".ENDP")));
+    }
+
+    @Test
+    @Tag("unit")
+    void bindingKeyNamesTheCallWithAPrecedingLabel() throws Exception {
+        assertBindingKeysPointAtCalls(compile(String.join("\n",
+                "SETI %DR0 DATA:29",
+                "LOOP:",
+                "CALL INC REF %DR0",
+                "WAIT",
+                ".ORG 0|1",
+                "EXPORT .PROC INC REF A",
+                "  ADDI A DATA:1",
+                "  RET",
+                ".ENDP")));
+    }
+
+    @Test
+    @Tag("unit")
+    void bindingKeysNameTheirCallsAcrossLabelsVectorsAndSeveralCalls() throws Exception {
+        // Several labels, a vector operand and two calls: every kind of item that occupies a
+        // different number of cells stands between the calls, so an address counted along the way
+        // would drift by a different amount at each of them.
+        ProgramArtifact artifact = compile(String.join("\n",
+                "SETI %DR0 DATA:1",
+                "START:",
+                "SETV %DR1 1|0",
+                "MIDDLE:",
+                "CALL INC REF %DR0",
+                "AGAIN:",
+                "SETV %DR2 0|1",
+                "CALL INC REF %DR1",
+                "WAIT",
+                ".ORG 0|1",
+                "EXPORT .PROC INC REF A",
+                "  ADDI A DATA:1",
+                "  RET",
+                ".ENDP"));
+
+        int callOpcode = Instruction.getInstructionIdByName("CALL");
+        assertThat(artifact.callSiteBindings()).as("both calls carry bindings").hasSize(2);
+
+        for (Map.Entry<Integer, Map<Integer, Integer>> binding : artifact.callSiteBindings().entrySet()) {
+            int linearAddress = binding.getKey();
+            int[] coord = artifact.linearAddressToCoord().get(linearAddress);
+            assertThat(coord).as("address %d is known", linearAddress).isNotNull();
+            assertThat(Molecule.fromInt(machineCodeAt(artifact, coord)).toScalarValue())
+                    .as("address %d holds a CALL", linearAddress)
+                    .isEqualTo(callOpcode);
+        }
     }
 
     private static ProgramArtifact compile(String source) throws Exception {

--- a/src/test/java/org/evochora/compiler/backend/link/LinkingContextFreezeTest.java
+++ b/src/test/java/org/evochora/compiler/backend/link/LinkingContextFreezeTest.java
@@ -19,7 +19,7 @@ class LinkingContextFreezeTest {
     void setUp() {
         context = new LinkingContext(null, null);
         context.pushAliasChain("ROOT");
-        context.nextAddress();
+        context.setCurrentAddress(1);
         context.callSiteBindings().put(0, new HashMap<>(Map.of(1024, 1, 1025, 2)));
         context.freeze();
     }
@@ -39,8 +39,8 @@ class LinkingContextFreezeTest {
     }
 
     @Test
-    void nextAddress_throwsAfterFreeze() {
-        assertThatThrownBy(() -> context.nextAddress())
+    void setCurrentAddress_throwsAfterFreeze() {
+        assertThatThrownBy(() -> context.setCurrentAddress(1))
                 .isInstanceOf(IllegalStateException.class);
     }
 

--- a/src/test/java/org/evochora/compiler/backend/link/features/CallSiteBindingRuleTest.java
+++ b/src/test/java/org/evochora/compiler/backend/link/features/CallSiteBindingRuleTest.java
@@ -42,7 +42,8 @@ class CallSiteBindingRuleTest {
         context = new LinkingContext(null, stubIsa);
         layout = new LayoutResult(
                 Collections.emptyMap(), Collections.emptyMap(),
-                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+                Collections.emptyList()
         );
         dummySource = new SourceInfo("test.s", 1, 0);
     }
@@ -141,8 +142,7 @@ class CallSiteBindingRuleTest {
 
     @Test
     void bindsAtCurrentAddress() {
-        context.nextAddress(); // advance to address 1
-        context.nextAddress(); // advance to address 2
+        context.setCurrentAddress(2); // the layout put this call at address 2
 
         IrInstruction call = new IrCallInstruction(
                 "CALL",

--- a/src/test/java/org/evochora/compiler/backend/link/features/LabelRefLinkingRuleTest.java
+++ b/src/test/java/org/evochora/compiler/backend/link/features/LabelRefLinkingRuleTest.java
@@ -53,7 +53,8 @@ class LabelRefLinkingRuleTest {
                 Map.of("5|5", 10),
                 Map.of("TEST.FOO", 10),
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
 
         // And: An instruction with IrLabelRef("FOO") from "test.s"
@@ -92,7 +93,8 @@ class LabelRefLinkingRuleTest {
                     Map.of("0|0", 0),
                     Map.of(qualifiedName, 0),
                     Collections.emptyMap(),
-                    Collections.emptyMap()
+                    Collections.emptyMap(),
+                    Collections.emptyList()
             );
 
             IrInstruction input = new IrInstruction(
@@ -127,7 +129,8 @@ class LabelRefLinkingRuleTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
 
         // Given: An instruction without IrLabelRef
@@ -152,7 +155,8 @@ class LabelRefLinkingRuleTest {
                 Collections.emptyMap(),
                 Map.of("TEST.OTHER_LABEL", 5), // Different label
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
 
         IrInstruction input = new IrInstruction(
@@ -198,7 +202,8 @@ class LabelRefLinkingRuleTest {
                 Map.of("5|5", 10),
                 Map.of("LIB.TARGET", 10),
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
 
         // And: An instruction referencing "LIB.TARGET" from main.s
@@ -251,7 +256,8 @@ class LabelRefLinkingRuleTest {
                 Map.of("5|5", 10),
                 Map.of("PRIVATE", 10),
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                Collections.emptyList()
         );
 
         // Instruction referencing "LIB.PRIVATE" from main.s


### PR DESCRIPTION
Fixes #130.

Two defects on the same path, found while writing the test #130 asks for as its first step. The first hid the second: as long as no binding key existed, none could be wrong.

## What was broken

**A call stopped being a call during linking.** `LabelRefLinkingRule` rebuilt the instruction as a plain `IrInstruction` whenever it rewrote an operand. A call's REF/VAL/LREF/LVAL lists live on its own IR type, so they were gone before `CallSiteBindingRule` — which runs after it — could read them. It found no call, collected nothing, and `callSiteBindings` went out empty. Every call targets a label and every label reference is rewritten, so this applied to every call in every program: the primordial's artifact carried **zero** bindings.

This is a regression from Compiler-2.0. Before it, the linker collected the bindings itself, *before* the rule loop; measure C10 moved that into a rule — correctly, the linker was to become a pure dispatcher — and the rule landed behind the one that discards the type.

**Two phases counted addresses differently.** The layout lets a label occupy a cell like any opcode; the linker advanced its own cursor only for instructions. Both numbers reach the artifact as "linear address" — the binding keys from the linker, the coordinate mappings from the layout — and they agree only for programs without labels. In the primordial the key pointed four cells short of its call, at the line before it.

## What it cost

Nothing at runtime, and that is by design: parameters are passed by `PUSH`/`POP` instructions in the machine code, and the bindings are display information the runtime never consults. What stopped working is the visualizer's parameter annotation. In `reproduce.evo` it shows `ER[%FDR0=D:108033]` — the value out of the formal register, without saying which register of the caller it came from. With both defects fixed it reads `ER[%DR0→%FDR0=D:108033]`.

## How it is fixed

An instruction reproduces its own kind when its operands are rewritten, so a rewriting rule no longer has to know which kinds exist — which is what the feature architecture asks for: binding information travels in the IR data stream and linking rules read it from there.

And the layout records the address it assigns to each item; the linker reads it instead of recomputing it. The rule for how many cells an item occupies now exists once instead of twice, and the linker loses its opcode lookup, signature query and vector-dimension arithmetic along with its cursor.

## Verification

- **Artifact comparison against the primordial:** of the artifact's fifteen parts, fourteen are byte-identical before and after — machine code layout and both coordinate mappings among them. Only the binding key moves, 137 → 141, from the line before the call to the call itself (`main.evo:62` → `main.evo:63` by the source map).
- **Mutation probe:** shifting the recorded address by one makes all three cases of the new test fail; reverting makes them pass. The test cannot go green by accident.
- **The new test** covers a call without a preceding label, one with, and a program where labels, a vector operand and two calls alternate — the item kinds that occupy different numbers of cells.
- Full suite: 2336 tests, 0 failures.
- Confirmed in the running visualizer against the working configuration.

## Commits

The first commit restores the bindings and makes the address defect visible; the second removes it. Each is green on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xceL1HuBDDxYLkA1BB3cE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected call-site address tracking so compiled call bindings consistently point to the cells containing their corresponding CALL instructions.
  * Improved address handling for programs containing labels, vector operands, multiple calls, and directives.
  * Preserved call and label operand information when instructions are rewritten during compilation.

* **Tests**
  * Added coverage validating emitted machine-code locations and call-site bindings across varied assembly programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->