### PR TITLE
Pass imports up and requirements down, both through more than one level

### DIFF
--- a/assembly/examples/modules.evo
+++ b/assembly/examples/modules.evo
@@ -1,17 +1,31 @@
 # Evochora Module System Example
-# Demonstrates .IMPORT, .REQUIRE, USING, .SOURCE, and EXPORT.
+# Demonstrates .IMPORT, EXPORT .IMPORT, .REQUIRE, USING, .SOURCE, and EXPORT.
 #
 # File structure:
 #   modules.evo              (this file — entry point)
 #   modules/constants.evo    (shared constants, loaded via .SOURCE)
 #   modules/math.evo         (standalone math utilities)
 #   modules/movement.evo     (movement, depends on math via .REQUIRE)
+#   modules/navigation.evo   (imports movement and passes it on via EXPORT .IMPORT)
+#
+# A module is wired to another one in one of two directions:
+#
+#   Downwards — the importer decides. A module names what it needs with .REQUIRE and
+#   whoever imports it satisfies that with USING. Both movement and navigation leave
+#   the choice open that way, so the decision made here reaches all the way down: this
+#   file names MATH once, navigation hands it on, and movement receives it.
+#
+#   Upwards — the imported module decides. It marks its own import with EXPORT, and its
+#   importer may then use it without placing that code a second time. That is how
+#   movement reaches this file, as NAV.MOVE.
 
-# Import the standalone math module
+# Import the standalone math module — its code is placed here
 .IMPORT "modules/math.evo" AS MATH
 
-# Import the movement module, wiring our MATH import to satisfy its .REQUIRE
-.IMPORT "modules/movement.evo" AS MOVE USING MATH AS MATH
+# Import navigation and give it the math module. Navigation hands it on to movement,
+# which required one without choosing it. Navigation also passes its own import of
+# movement back up, so we reach it as NAV.MOVE without placing that code again.
+.IMPORT "modules/navigation.evo" AS NAV USING MATH AS MATH
 
 # Load shared constants for direct use in this file
 .SOURCE "modules/constants.evo"
@@ -39,8 +53,12 @@ MAIN_LOOP:
   LTI %ENERGY MOVE_COST
   JMPI MAIN_LOOP
 
-  # Move north
-  CALL MOVE.NORTH REF %POS_Y
+  # Move north through the passed-on import: movement's code lives inside navigation,
+  # this file only names it
+  CALL NAV.MOVE.NORTH REF %POS_Y
+
+  # And a procedure of navigation itself
+  CALL NAV.PATROL REF %POS_X REF %POS_Y
 
   # Consume movement cost
   SUBI %ENERGY MOVE_COST

--- a/assembly/examples/modules.evo
+++ b/assembly/examples/modules.evo
@@ -12,20 +12,22 @@
 #
 #   Downwards — the importer decides. A module names what it needs with .REQUIRE and
 #   whoever imports it satisfies that with USING. Both movement and navigation leave
-#   the choice open that way, so the decision made here reaches all the way down: this
-#   file names MATH once, navigation hands it on, and movement receives it.
+#   the choice open that way, so the decision made here reaches all the way down. Each
+#   level uses its own name for the same module: MATHLIB here, ARITH inside navigation,
+#   CALC inside movement — and each USING clause says which name means which.
 #
 #   Upwards — the imported module decides. It marks its own import with EXPORT, and its
 #   importer may then use it without placing that code a second time. That is how
 #   movement reaches this file, as NAV.MOVE.
 
 # Import the standalone math module — its code is placed here
-.IMPORT "modules/math.evo" AS MATH
+.IMPORT "modules/math.evo" AS MATHLIB
 
-# Import navigation and give it the math module. Navigation hands it on to movement,
-# which required one without choosing it. Navigation also passes its own import of
-# movement back up, so we reach it as NAV.MOVE without placing that code again.
-.IMPORT "modules/navigation.evo" AS NAV USING MATH AS MATH
+# Import navigation and give it our math module: what we call MATHLIB is what navigation
+# asked for as ARITH. Navigation hands it on to movement under yet another name, and
+# passes its own import of movement back up, so we reach it as NAV.MOVE without placing
+# that code again.
+.IMPORT "modules/navigation.evo" AS NAV USING MATHLIB AS ARITH
 
 # Load shared constants for direct use in this file
 .SOURCE "modules/constants.evo"
@@ -47,7 +49,7 @@ START:
 
 MAIN_LOOP:
   # Gain some energy each tick (clamped to MAX_ENERGY)
-  CALL MATH.ADD_CLAMPED REF %ENERGY VAL DATA:3 MAX_ENERGY
+  CALL MATHLIB.ADD_CLAMPED REF %ENERGY VAL DATA:3 MAX_ENERGY
 
   # Only move if we have enough energy
   LTI %ENERGY MOVE_COST

--- a/assembly/examples/modules/movement.evo
+++ b/assembly/examples/modules/movement.evo
@@ -2,33 +2,33 @@
 # Declares a dependency on a math module via .REQUIRE.
 # The importer must satisfy this dependency with a USING clause.
 
-.REQUIRE "math.evo" AS MATH
+.REQUIRE "math.evo" AS CALC
 .SOURCE "modules/constants.evo"
 
 # Move north (Y - 1), clamped to world bounds.
 EXPORT .PROC NORTH REF Y
   SUBI Y DATA:1
-  CALL MATH.CLAMP REF Y VAL WORLD_MIN WORLD_MAX
+  CALL CALC.CLAMP REF Y VAL WORLD_MIN WORLD_MAX
   RET
 .ENDP
 
 # Move south (Y + 1), clamped to world bounds.
 EXPORT .PROC SOUTH REF Y
   ADDI Y DATA:1
-  CALL MATH.CLAMP REF Y VAL WORLD_MIN WORLD_MAX
+  CALL CALC.CLAMP REF Y VAL WORLD_MIN WORLD_MAX
   RET
 .ENDP
 
 # Move east (X + 1), clamped to world bounds.
 EXPORT .PROC EAST REF X
   ADDI X DATA:1
-  CALL MATH.CLAMP REF X VAL WORLD_MIN WORLD_MAX
+  CALL CALC.CLAMP REF X VAL WORLD_MIN WORLD_MAX
   RET
 .ENDP
 
 # Move west (X - 1), clamped to world bounds.
 EXPORT .PROC WEST REF X
   SUBI X DATA:1
-  CALL MATH.CLAMP REF X VAL WORLD_MIN WORLD_MAX
+  CALL CALC.CLAMP REF X VAL WORLD_MIN WORLD_MAX
   RET
 .ENDP

--- a/assembly/examples/modules/navigation.evo
+++ b/assembly/examples/modules/navigation.evo
@@ -1,0 +1,26 @@
+# Navigation module.
+#
+# Shows both directions in which modules are wired together, and that neither is
+# limited to a single level.
+#
+#   Downwards, with .REQUIRE and USING — movement names its dependency and leaves the
+#   choice to whoever imports it. This module makes the same choice its own importer's
+#   business: it requires math rather than importing one, and hands on what it was
+#   given. Only the outermost file decides which math module finally arrives.
+#
+#   Upwards, with EXPORT — our import of movement carries the prefix, so whoever
+#   imports us reaches it as NAV.MOVE.NAME. Its code is placed here, once, and named
+#   from above.
+#
+# Without the prefix the import would stay private: an importer could call NAV.PATROL,
+# but not NAV.MOVE.NORTH.
+
+.REQUIRE "math.evo" AS MATH
+EXPORT .IMPORT "modules/movement.evo" AS MOVE USING MATH AS MATH
+
+# Move one step north and one step east.
+EXPORT .PROC PATROL REF X REF Y
+  CALL MOVE.NORTH REF Y
+  CALL MOVE.EAST REF X
+  RET
+.ENDP

--- a/assembly/examples/modules/navigation.evo
+++ b/assembly/examples/modules/navigation.evo
@@ -3,10 +3,12 @@
 # Shows both directions in which modules are wired together, and that neither is
 # limited to a single level.
 #
-#   Downwards, with .REQUIRE and USING — movement names its dependency and leaves the
-#   choice to whoever imports it. This module makes the same choice its own importer's
-#   business: it requires math rather than importing one, and hands on what it was
-#   given. Only the outermost file decides which math module finally arrives.
+#   Downwards, with .REQUIRE and USING — movement names its dependency CALC and leaves
+#   the choice to whoever imports it. This module makes the same choice its own
+#   importer's business: it requires a math module as ARITH rather than importing one,
+#   and hands that on to movement. Every level names the dependency as it likes; USING
+#   reads "the module I know as ARITH is the one you asked for as CALC". Only the
+#   outermost file decides which module finally arrives.
 #
 #   Upwards, with EXPORT — our import of movement carries the prefix, so whoever
 #   imports us reaches it as NAV.MOVE.NAME. Its code is placed here, once, and named
@@ -15,8 +17,8 @@
 # Without the prefix the import would stay private: an importer could call NAV.PATROL,
 # but not NAV.MOVE.NORTH.
 
-.REQUIRE "math.evo" AS MATH
-EXPORT .IMPORT "modules/movement.evo" AS MOVE USING MATH AS MATH
+.REQUIRE "math.evo" AS ARITH
+EXPORT .IMPORT "modules/movement.evo" AS MOVE USING ARITH AS CALC
 
 # Move one step north and one step east.
 EXPORT .PROC PATROL REF X REF Y

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,6 +223,10 @@ tasks.withType<Tar> {
 
 tasks.test {
     useJUnitPlatform()
+    // The assembly programs are compiled by a test, so a change to one has to invalidate the
+    // task. Gradle decides that per task, not per test class: touching a program reruns the
+    // suite, which is the price for the examples and the primordial staying compilable.
+    inputs.dir("assembly").withPropertyName("assemblyPrograms")
     maxHeapSize = "2g" // Increase heap size for tests
     jvmArgs("-Duser.language=en", "-Duser.country=US")
     jvmArgs("-XX:+EnableDynamicAgentLoading")

--- a/docs/ASSEMBLY_SPEC.md
+++ b/docs/ASSEMBLY_SPEC.md
@@ -614,7 +614,7 @@ Both syntaxes produce identical results—the shorthand is transformed into `.RE
 
 The module system allows splitting programs across multiple files. Three directives work together to manage module dependencies:
 
-* **`.IMPORT`** — imports a module: establishes a dependency and inlines the module's code.
+* **`.IMPORT`** — imports a module: establishes a dependency and inlines the module's code; with the `EXPORT` prefix it also passes that import on to its own importers.
 * **`.REQUIRE`** — declares an unsatisfied dependency that must be provided by the importer via a `USING` clause.
 * **`.SOURCE`** — includes raw source text (macros, constants) without creating a module relationship.
 

--- a/docs/ASSEMBLY_SPEC.md
+++ b/docs/ASSEMBLY_SPEC.md
@@ -624,7 +624,7 @@ The module system allows splitting programs across multiple files. Three directi
 * **Effect**: Declares a dependency on the module at `<path>`, assigns it the local alias `<Alias>`, and inlines the module's code at this location. Exported labels and procedures in the imported module become accessible as `<Alias>.<Name>`.
 * **`EXPORT` prefix**: Passes the import on to modules that import this one, which then reach it as `<ThisAlias>.<Alias>.<Name>` without inlining the code a second time. Each level decides for its own import: a level without the prefix ends the chain there.
 * **USING clauses**: Provide compile-time dependency injection. Each `USING` clause wires a module from the current scope (identified by `<source>` alias) into the imported module to satisfy one of its `.REQUIRE` declarations (identified by `<target>` alias).
-    - `<source>` must be a known import alias in the current module.
+    - `<source>` names a module the current one has: either one it imported itself, or one it received through a `USING` clause on its own `.REQUIRE`. The second case lets a module hand a dependency further down without choosing it, so the decision stays with the outermost caller.
     - `<target>` must match a `.REQUIRE` alias in the imported module.
     - Every `.REQUIRE` in the imported module must be satisfied by a `USING` clause.
 
@@ -782,6 +782,7 @@ The module example consists of multiple files:
 | [`modules/constants.evo`](../assembly/examples/modules/constants.evo) | Shared constants loaded via `.SOURCE` |
 | [`modules/math.evo`](../assembly/examples/modules/math.evo) | Standalone math utilities (no dependencies) |
 | [`modules/movement.evo`](../assembly/examples/modules/movement.evo) | Movement procedures, depends on math via `.REQUIRE` |
+| [`modules/navigation.evo`](../assembly/examples/modules/navigation.evo) | Passes a required math module down to movement and its own import of movement back up via `EXPORT .IMPORT` |
 
 To compile the examples using the CLI:
 

--- a/docs/ASSEMBLY_SPEC.md
+++ b/docs/ASSEMBLY_SPEC.md
@@ -620,8 +620,9 @@ The module system allows splitting programs across multiple files. Three directi
 
 #### `.IMPORT`
 
-* **Syntax**: `.IMPORT "<path>" AS <Alias> [USING <source> AS <target>]*`
+* **Syntax**: `[EXPORT] .IMPORT "<path>" AS <Alias> [USING <source> AS <target>]*`
 * **Effect**: Declares a dependency on the module at `<path>`, assigns it the local alias `<Alias>`, and inlines the module's code at this location. Exported labels and procedures in the imported module become accessible as `<Alias>.<Name>`.
+* **`EXPORT` prefix**: Passes the import on to modules that import this one, which then reach it as `<ThisAlias>.<Alias>.<Name>` without inlining the code a second time. Each level decides for its own import: a level without the prefix ends the chain there.
 * **USING clauses**: Provide compile-time dependency injection. Each `USING` clause wires a module from the current scope (identified by `<source>` alias) into the imported module to satisfy one of its `.REQUIRE` declarations (identified by `<target>` alias).
     - `<source>` must be a known import alias in the current module.
     - `<target>` must match a `.REQUIRE` alias in the imported module.
@@ -772,7 +773,7 @@ Complete, compilable example programs are provided in [`assembly/examples/`](../
 |---|---|
 | [`simple.evo`](../assembly/examples/simple.evo) | Basic syntax: register aliases, `.DEFINE`, `.PROC`, labels, loops |
 | [`complex.evo`](../assembly/examples/complex.evo) | Advanced features: `.PLACE`, `.MACRO`, `.REPEAT`, `.SOURCE`, multiple `.ORG` regions |
-| [`modules.evo`](../assembly/examples/modules.evo) | Module system: `.IMPORT`, `.REQUIRE`, `USING`, `.SOURCE` for shared constants, `EXPORT` |
+| [`modules.evo`](../assembly/examples/modules.evo) | Module system: `.IMPORT`, `EXPORT .IMPORT`, `.REQUIRE`, `USING`, `.SOURCE` for shared constants, `EXPORT` |
 
 The module example consists of multiple files:
 

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
@@ -48,11 +48,14 @@ public class ImportAnalysisHandler implements IAnalysisHandler {
             String sourceAlias = using.sourceAlias().toUpperCase();
             String targetAlias = using.targetAlias().toUpperCase();
 
-            // USING source must be a known import alias in the current module
-            if (!currentModScope.imports().containsKey(sourceAlias)) {
+            // A USING source is either a module this one imported, or one it was given itself:
+            // a requirement received from above can be handed on, so that the choice of what
+            // finally arrives stays with the outermost caller.
+            if (!currentModScope.imports().containsKey(sourceAlias)
+                    && !currentModScope.usingBindings().containsKey(sourceAlias)) {
                 diagnostics.reportError(
                         "USING source '" + using.sourceAlias()
-                                + "' is not a known import alias in the current module.",
+                                + "' is neither an import nor a requirement of the current module.",
                         using.sourceSourceInfo().fileName(),
                         using.sourceSourceInfo().lineNumber());
             }

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
@@ -42,6 +42,19 @@ public class ImportAnalysisHandler implements IAnalysisHandler {
             return;
         }
 
+        // The EXPORT prefix is read twice from the same line: once by the dependency scanner,
+        // whose result decides what the module actually re-exports, and once by the parser, whose
+        // result reaches here on the node. Two descriptions of one syntax can drift apart, and a
+        // drift would silently change which symbols a module passes on, so it is an error here.
+        Boolean scannedAsExported = currentModScope.importExported().get(alias);
+        if (scannedAsExported != null && scannedAsExported != importNode.exported()) {
+            diagnostics.reportError(
+                    "Internal error: the dependency scan and the parser disagree on whether import '"
+                            + importNode.alias() + "' is exported.",
+                    importNode.sourceInfo().fileName(),
+                    importNode.sourceInfo().lineNumber());
+        }
+
         ModuleScope importedModScope = symbolTable.getModuleScope(importedAliasChain).orElse(null);
 
         for (ImportNode.UsingClause using : importNode.usings()) {

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
@@ -11,7 +11,7 @@ import org.evochora.compiler.model.symbols.SymbolTable;
  *
  * <p>Validates USING clauses:
  * <ul>
- *   <li>Each USING source must be a known import alias in the current module.</li>
+ *   <li>Each USING source must be an import of the current module, or a requirement it received itself.</li>
  *   <li>Each USING target must correspond to a {@code .REQUIRE} declaration in the imported module.</li>
  *   <li>All {@code .REQUIRE} declarations in the imported module must be satisfied by USING clauses.</li>
  * </ul>

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportAnalysisHandler.java
@@ -53,6 +53,7 @@ public class ImportAnalysisHandler implements IAnalysisHandler {
                             + importNode.alias() + "' is exported.",
                     importNode.sourceInfo().fileName(),
                     importNode.sourceInfo().lineNumber());
+            return;
         }
 
         ModuleScope importedModScope = symbolTable.getModuleScope(importedAliasChain).orElse(null);

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportDependencyInfo.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportDependencyInfo.java
@@ -11,12 +11,14 @@ import java.util.List;
  * @param alias The local alias for the imported module.
  * @param usings The USING clauses on this import.
  * @param resolvedPath The resolved absolute path of the imported module.
+ * @param exported Whether the importing module passes this import on to its own importers.
  */
 public record ImportDependencyInfo(
         String path,
         String alias,
         List<UsingDecl> usings,
-        String resolvedPath
+        String resolvedPath,
+        boolean exported
 ) implements IDependencyInfo {
 
     @Override public String directiveName() { return ".IMPORT"; }

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportDependencyScanHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportDependencyScanHandler.java
@@ -16,8 +16,11 @@ import java.util.regex.Pattern;
  */
 public class ImportDependencyScanHandler implements IDependencyScanHandler {
 
+    // The same syntax is described a second time by the parser handler for this directive.
+    // Whatever changes here has to change there as well: a form this pattern does not match is
+    // never scanned, so the module is never loaded, and the parser never gets to see it.
     private static final Pattern IMPORT_PATTERN = Pattern.compile(
-            "(?i)^\\.IMPORT\\s+\"([^\"]+)\"\\s+AS\\s+(\\w+)((?:\\s+USING\\s+\\w+\\s+AS\\s+\\w+)*)\\s*$");
+            "(?i)^(EXPORT\\s+)?\\.IMPORT\\s+\"([^\"]+)\"\\s+AS\\s+(\\w+)((?:\\s+USING\\s+\\w+\\s+AS\\s+\\w+)*)\\s*$");
     private static final Pattern USING_PATTERN = Pattern.compile(
             "(?i)USING\\s+(\\w+)\\s+AS\\s+(\\w+)");
 
@@ -28,9 +31,10 @@ public class ImportDependencyScanHandler implements IDependencyScanHandler {
 
     @Override
     public void handleMatch(Matcher matcher, IDependencyScanContext ctx) {
-        String path = matcher.group(1);
-        String alias = matcher.group(2);
-        String usingsPart = matcher.group(3);
+        boolean exported = matcher.group(1) != null;
+        String path = matcher.group(2);
+        String alias = matcher.group(3);
+        String usingsPart = matcher.group(4);
 
         List<ImportDependencyInfo.UsingDecl> usings = new ArrayList<>();
         if (usingsPart != null && !usingsPart.isBlank()) {
@@ -48,7 +52,7 @@ public class ImportDependencyScanHandler implements IDependencyScanHandler {
             return;
         }
 
-        ctx.addDependency(new ImportDependencyInfo(path, alias, usings, resolvedPath));
+        ctx.addDependency(new ImportDependencyInfo(path, alias, usings, resolvedPath, exported));
 
         try {
             String content = ctx.loadContent(resolvedPath);

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportDirectiveHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportDirectiveHandler.java
@@ -24,6 +24,9 @@ public class ImportDirectiveHandler implements IParserStatementHandler {
 
     @Override
     public AstNode parse(ParsingContext context) {
+        // The dependency scanner describes this directive's syntax a second time, as a regular
+        // expression, and decides from it which modules are loaded at all. A form accepted here
+        // but not there reaches the parser with its module missing.
         boolean exported = context.isExported();
         context.advance(); // consume .IMPORT
 

--- a/src/main/java/org/evochora/compiler/features/importdir/ImportModuleSetupHandler.java
+++ b/src/main/java/org/evochora/compiler/features/importdir/ImportModuleSetupHandler.java
@@ -29,6 +29,10 @@ public class ImportModuleSetupHandler implements IDependencySetupHandler<ImportD
         ModuleScope modScope = ctx.getModuleScope(ctx.currentAliasChain());
         if (modScope != null) {
             modScope.imports().put(importAlias, importedAliasChain);
+            // Whether a name may reach through this import from outside. Resolution walks the
+            // chain segment by segment and asks at every step, so a module that keeps its import
+            // to itself ends the chain there.
+            modScope.importExported().put(importAlias, dep.exported());
         }
     }
 
@@ -42,7 +46,12 @@ public class ImportModuleSetupHandler implements IDependencySetupHandler<ImportD
             String sourceAlias = using.sourceAlias().toUpperCase();
             ModuleScope importerScope = ctx.getModuleScope(ctx.currentAliasChain());
             if (importerScope == null) continue;
+            // Either a module this one imported, or one it received itself - the latter is what
+            // lets a requirement travel further down than the module that first accepted it.
             String sourceAliasChain = importerScope.imports().get(sourceAlias);
+            if (sourceAliasChain == null) {
+                sourceAliasChain = importerScope.usingBindings().get(sourceAlias);
+            }
             if (sourceAliasChain != null) {
                 importedModScope.usingBindings().put(using.targetAlias().toUpperCase(), sourceAliasChain);
             }

--- a/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
@@ -16,19 +16,19 @@ import org.evochora.compiler.frontend.module.IDependencyInfo;
 public interface IDependencySetupHandler<T extends IDependencyInfo> {
 
     /**
-     * Pass 1: Compute alias chains for this dependency.
+     * Step 1: Compute alias chains for this dependency.
      * Called in reverse topological order (root first).
      */
     void registerScope(T dependency, ModuleSetupContext ctx);
 
     /**
-     * Pass 2: Register relationships in module scopes.
+     * Step 2: Register relationships in module scopes.
      * Called in topological order after all modules are registered in the symbol table.
      */
     default void registerRelationships(T dependency, ModuleSetupContext ctx) {}
 
     /**
-     * Pass 3: Resolve cross-module bindings (e.g., USING).
+     * Step 3: Resolve cross-module bindings (e.g., USING).
      * <p>
      * Called in reverse topological order (root first), after all relationships are registered.
      * A module may hand on a dependency it was given itself, and can only do so once the module

--- a/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
@@ -4,7 +4,7 @@ import org.evochora.compiler.frontend.module.IDependencyInfo;
 
 /**
  * Handler for setting up module relationships from dependency data.
- * Called during Phase 4 (before AST walk) in three passes:
+ * Called during Phase 4 (before AST walk) in three steps:
  * <ol>
  *   <li>registerScope — compute alias chains (reverse topological order)</li>
  *   <li>registerRelationships — register relationships in module scopes (after all modules registered)</li>
@@ -32,7 +32,7 @@ public interface IDependencySetupHandler<T extends IDependencyInfo> {
      * <p>
      * Called in reverse topological order (root first), after all relationships are registered.
      * A module may hand on a dependency it was given itself, and can only do so once the module
-     * above it has bound that dependency — which happens in this same pass.
+     * above it has bound that dependency — which happens in this same step.
      */
     default void resolveBindings(T dependency, ModuleSetupContext ctx) {}
 }

--- a/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/IDependencySetupHandler.java
@@ -8,7 +8,7 @@ import org.evochora.compiler.frontend.module.IDependencyInfo;
  * <ol>
  *   <li>registerScope — compute alias chains (reverse topological order)</li>
  *   <li>registerRelationships — register relationships in module scopes (after all modules registered)</li>
- *   <li>resolveBindings — resolve cross-module bindings like USING (after all relationships registered)</li>
+ *   <li>resolveBindings — resolve cross-module bindings like USING (reverse topological order)</li>
  * </ol>
  *
  * @param <T> The specific dependency info type this handler processes.
@@ -29,7 +29,10 @@ public interface IDependencySetupHandler<T extends IDependencyInfo> {
 
     /**
      * Pass 3: Resolve cross-module bindings (e.g., USING).
-     * Called in topological order after all relationships are registered.
+     * <p>
+     * Called in reverse topological order (root first), after all relationships are registered.
+     * A module may hand on a dependency it was given itself, and can only do so once the module
+     * above it has bound that dependency — which happens in this same pass.
      */
     default void resolveBindings(T dependency, ModuleSetupContext ctx) {}
 }

--- a/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
@@ -11,6 +11,8 @@ import org.evochora.compiler.model.ModuleContextTracker;
 import org.evochora.compiler.model.symbols.SymbolTable;
 
 import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -165,7 +167,14 @@ public class SemanticAnalyzer {
         }
 
         // Pass 3: Resolve cross-module bindings (USING etc.).
-        for (ModuleDescriptor module : topoOrder) {
+        //
+        // Walked from the outermost module inwards, the reverse of the dependency order: a module
+        // may hand on a dependency it was given itself, and it can only do that once it has been
+        // given it. The order is finite because the module graph is acyclic - a cycle among
+        // modules is reported during scanning and never reaches this point.
+        List<ModuleDescriptor> outermostFirst = new ArrayList<>(topoOrder);
+        Collections.reverse(outermostFirst);
+        for (ModuleDescriptor module : outermostFirst) {
             ModuleSetupContext ctx = new ModuleSetupContext(symbolTable, diagnostics, pathToAliasChain, module.sourcePath());
             for (IDependencyInfo dep : module.dependencies()) {
                 IDependencySetupHandler<IDependencyInfo> handler = setupRegistry.resolve(dep.getClass());

--- a/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
@@ -127,12 +127,15 @@ public class SemanticAnalyzer {
     private void setupModuleRelationships(DependencyGraph graph, String mainFilePath, String rootAliasChain) {
         List<ModuleDescriptor> topoOrder = graph.topologicalOrder();
 
-        // Pass 1: Compute alias chains (reverse topological — root first, then dependencies).
+        // Dependencies come first in the topological order; two of the passes below need the
+        // opposite, each for its own reason, and both mean the same sequence.
+        List<ModuleDescriptor> fromRoot = new ArrayList<>(topoOrder);
+        Collections.reverse(fromRoot);
+
+        // Pass 1: Compute alias chains (root first, then dependencies).
         Map<String, String> pathToAliasChain = new HashMap<>();
         pathToAliasChain.put(mainFilePath, rootAliasChain);
 
-        List<ModuleDescriptor> fromRoot = new java.util.ArrayList<>(topoOrder);
-        java.util.Collections.reverse(fromRoot);
         for (ModuleDescriptor module : fromRoot) {
             String modulePath = module.sourcePath();
             String moduleAliasChain = pathToAliasChain.get(modulePath);
@@ -168,13 +171,11 @@ public class SemanticAnalyzer {
 
         // Pass 3: Resolve cross-module bindings (USING etc.).
         //
-        // Walked from the outermost module inwards, the reverse of the dependency order: a module
-        // may hand on a dependency it was given itself, and it can only do that once it has been
-        // given it. The order is finite because the module graph is acyclic - a cycle among
-        // modules is reported during scanning and never reaches this point.
-        List<ModuleDescriptor> outermostFirst = new ArrayList<>(topoOrder);
-        Collections.reverse(outermostFirst);
-        for (ModuleDescriptor module : outermostFirst) {
+        // Walked from the outermost module inwards: a module may hand on a dependency it was given
+        // itself, and it can only do that once it has been given it. The walk is finite because the
+        // module graph is acyclic - a cycle among modules is reported during scanning and never
+        // reaches this point.
+        for (ModuleDescriptor module : fromRoot) {
             ModuleSetupContext ctx = new ModuleSetupContext(symbolTable, diagnostics, pathToAliasChain, module.sourcePath());
             for (IDependencyInfo dep : module.dependencies()) {
                 IDependencySetupHandler<IDependencyInfo> handler = setupRegistry.resolve(dep.getClass());

--- a/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
@@ -132,7 +132,7 @@ public class SemanticAnalyzer {
         List<ModuleDescriptor> fromRoot = new ArrayList<>(topoOrder);
         Collections.reverse(fromRoot);
 
-        // Pass 1: Compute alias chains (root first, then dependencies).
+        // Step 1: Compute alias chains (root first, then dependencies).
         Map<String, String> pathToAliasChain = new HashMap<>();
         pathToAliasChain.put(mainFilePath, rootAliasChain);
 
@@ -152,7 +152,7 @@ public class SemanticAnalyzer {
             }
         }
 
-        // Pass 2: Register all modules, then dispatch relationship registration.
+        // Step 2: Register all modules, then dispatch relationship registration.
         for (ModuleDescriptor module : topoOrder) {
             String modulePath = module.sourcePath();
             String moduleAliasChain = pathToAliasChain.getOrDefault(modulePath,
@@ -169,7 +169,7 @@ public class SemanticAnalyzer {
             }
         }
 
-        // Pass 3: Resolve cross-module bindings (USING etc.).
+        // Step 3: Resolve cross-module bindings (USING etc.).
         //
         // Walked from the outermost module inwards: a module may hand on a dependency it was given
         // itself, and it can only do that once it has been given it. The walk is finite because the

--- a/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
+++ b/src/main/java/org/evochora/compiler/frontend/semantics/SemanticAnalyzer.java
@@ -127,7 +127,7 @@ public class SemanticAnalyzer {
     private void setupModuleRelationships(DependencyGraph graph, String mainFilePath, String rootAliasChain) {
         List<ModuleDescriptor> topoOrder = graph.topologicalOrder();
 
-        // Dependencies come first in the topological order; two of the passes below need the
+        // Dependencies come first in the topological order; two of the steps below need the
         // opposite, each for its own reason, and both mean the same sequence.
         List<ModuleDescriptor> fromRoot = new ArrayList<>(topoOrder);
         Collections.reverse(fromRoot);

--- a/src/main/java/org/evochora/compiler/model/symbols/SymbolTable.java
+++ b/src/main/java/org/evochora/compiler/model/symbols/SymbolTable.java
@@ -307,7 +307,11 @@ public class SymbolTable {
 
     /**
      * Recursively resolves multi-level qualified names (e.g., "A.B.C.LABEL").
-     * At each level, checks that the import is EXPORT-visible before descending.
+     * <p>
+     * Every step but the last leads through an import the module marked with EXPORT. A module's
+     * requirements are deliberately not steps: a requirement is satisfied by the importer, who
+     * therefore already has a name for that module and does not reach it through the module it
+     * handed it to.
      */
     private Optional<ResolvedSymbol> resolveMultiLevel(String currentChain, String remainder) {
         int dot = remainder.indexOf('.');
@@ -331,9 +335,6 @@ public class SymbolTable {
         if (modScope == null) return Optional.empty();
 
         String nextChain = modScope.imports().get(nextAlias);
-        if (nextChain == null) {
-            nextChain = modScope.usingBindings().get(nextAlias);
-        }
         if (nextChain == null) return Optional.empty();
 
         Boolean exp = modScope.importExported().get(nextAlias);

--- a/src/test/java/org/evochora/compiler/AssemblyProgramsCompileTest.java
+++ b/src/test/java/org/evochora/compiler/AssemblyProgramsCompileTest.java
@@ -1,0 +1,56 @@
+package org.evochora.compiler;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.evochora.compiler.api.CompilerOptions;
+import org.evochora.compiler.api.ProgramArtifact;
+import org.evochora.compiler.api.SourceRoot;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.EnvironmentProperties;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compiles the assembly programs kept in this repository.
+ * <p>
+ * The examples are documentation that has to work: the reference names them by file and gives the
+ * command line that translates them, so a reader is entitled to expect that it does. The primordial
+ * organism is what the simulation actually runs. Both reach further than the unit tests around the
+ * module system, which build their modules in a temporary directory — these resolve paths through a
+ * source root and nest modules several levels deep, which is where module resolution is easiest to
+ * break without noticing.
+ */
+class AssemblyProgramsCompileTest {
+
+    private static final EnvironmentProperties ENV = new EnvironmentProperties(new int[]{100, 100}, true);
+
+    @BeforeAll
+    static void init() {
+        Instruction.init();
+    }
+
+    @ParameterizedTest(name = "{1} from {0}")
+    @CsvSource({
+            "assembly/examples,   simple.evo",
+            "assembly/examples,   complex.evo",
+            "assembly/examples,   modules.evo",
+            "assembly/primordial, main.evo",
+    })
+    @Tag("integration")
+    void aProgramInThisRepositoryCompiles(String sourceRootPath, String fileName) throws Exception {
+        String sourceRoot = Path.of("").toAbsolutePath().resolve(sourceRootPath).toString();
+        CompilerOptions options = new CompilerOptions(List.of(new SourceRoot(sourceRoot, null)));
+
+        ProgramArtifact artifact = new Compiler().compile(fileName, ENV, options);
+
+        assertThat(artifact).isNotNull();
+        assertThat(artifact.machineCodeLayout())
+                .as("%s produces machine code", fileName)
+                .isNotEmpty();
+    }
+}

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/ImportAnalysisHandlerTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/ImportAnalysisHandlerTest.java
@@ -157,11 +157,61 @@ class ImportAnalysisHandlerTest {
         assertErrorContaining("EXTRA", "no USING clause provides it");
     }
 
+    @Test
+    @Tag("unit")
+    void anExportMarkerTheScanAndTheParserReadDifferentlyIsReported() {
+        // The scan recorded an exported import, the parser saw none on the same line.
+        ModuleScope mainScope = symbolTable.getModuleScope(MAIN_CHAIN).orElseThrow();
+        mainScope.importExported().put("D", true);
+
+        ImportNode node = importNode("dep.evo", "D", List.of(), false);
+
+        handler.analyze(node, symbolTable, diagnostics);
+
+        assertErrorContaining("D", "disagree on whether import");
+    }
+
+    @Test
+    @Tag("unit")
+    void anExportMarkerBothReadTheSameWayPassesValidation() {
+        ModuleScope mainScope = symbolTable.getModuleScope(MAIN_CHAIN).orElseThrow();
+        mainScope.importExported().put("D", true);
+
+        ImportNode node = importNode("dep.evo", "D", List.of(), true);
+
+        handler.analyze(node, symbolTable, diagnostics);
+
+        assertNoErrors();
+    }
+
+    @Test
+    @Tag("unit")
+    void aContradictingImportIsNotValidatedAnyFurther() {
+        // The USING clause below is invalid as well, but analysis stops at the contradiction
+        // rather than adding a second, unrelated complaint about a state known to be broken.
+        ModuleScope mainScope = symbolTable.getModuleScope(MAIN_CHAIN).orElseThrow();
+        mainScope.importExported().put("LIB", true);
+
+        ImportNode node = importNode("lib.evo", "LIB", List.of(
+                usingClause("UNKNOWN", "DEP")
+        ), false);
+
+        handler.analyze(node, symbolTable, diagnostics);
+
+        assertThat(diagnostics.getDiagnostics()).hasSize(1);
+        assertErrorContaining("LIB", "disagree on whether import");
+    }
+
     // --- Helper methods ---
 
     private ImportNode importNode(String path, String alias, List<ImportNode.UsingClause> usings) {
+        return importNode(path, alias, usings, false);
+    }
+
+    private ImportNode importNode(String path, String alias, List<ImportNode.UsingClause> usings,
+                                  boolean exported) {
         SourceInfo sourceInfo = new SourceInfo(MAIN_FILE, 1, 20);
-        return new ImportNode(path, alias, usings, false, sourceInfo);
+        return new ImportNode(path, alias, usings, exported, sourceInfo);
     }
 
     private ImportNode.UsingClause usingClause(String sourceAlias, String targetAlias) {

--- a/src/test/java/org/evochora/compiler/frontend/semantics/analysis/ImportAnalysisHandlerTest.java
+++ b/src/test/java/org/evochora/compiler/frontend/semantics/analysis/ImportAnalysisHandlerTest.java
@@ -83,14 +83,14 @@ class ImportAnalysisHandlerTest {
     @Tag("unit")
     void unknownSourceAliasReportsError() {
         // .IMPORT "lib.evo" AS LIB USING UNKNOWN AS DEP
-        // "UNKNOWN" is not a known import alias in main
+        // "UNKNOWN" is neither imported nor required by main
         ImportNode node = importNode("lib.evo", "LIB", List.of(
                 usingClause("UNKNOWN", "DEP")
         ));
 
         handler.analyze(node, symbolTable, diagnostics);
 
-        assertErrorContaining("UNKNOWN", "not a known import alias");
+        assertErrorContaining("UNKNOWN", "neither an import nor a requirement");
     }
 
     @Test

--- a/src/test/java/org/evochora/compiler/module/ImportPatternTest.java
+++ b/src/test/java/org/evochora/compiler/module/ImportPatternTest.java
@@ -1,0 +1,82 @@
+package org.evochora.compiler.module;
+
+import org.evochora.compiler.features.importdir.ImportDependencyScanHandler;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the pattern by which the dependency scan recognises an {@code .IMPORT} line.
+ * <p>
+ * A line this pattern misses is never scanned, so the module behind it is never loaded and the
+ * parser never sees it; a group it captures wrongly decides what a module re-exports. Both are
+ * silent failures at the very front of the pipeline, which is why the syntax is pinned here in
+ * isolation rather than only through programs that happen to use it.
+ */
+class ImportPatternTest {
+
+    private static final Pattern PATTERN = new ImportDependencyScanHandler().pattern();
+
+    private static Matcher match(String line) {
+        Matcher matcher = PATTERN.matcher(line);
+        assertThat(matcher.matches()).as("'%s' is recognised as an import", line).isTrue();
+        return matcher;
+    }
+
+    @Test
+    @Tag("unit")
+    void aPlainImportCarriesNoExportMarker() {
+        Matcher matcher = match(".IMPORT \"modules/math.evo\" AS MATHLIB");
+
+        assertThat(matcher.group(1)).isNull();
+        assertThat(matcher.group(2)).isEqualTo("modules/math.evo");
+        assertThat(matcher.group(3)).isEqualTo("MATHLIB");
+    }
+
+    @Test
+    @Tag("unit")
+    void theExportPrefixIsCaptured() {
+        Matcher matcher = match("EXPORT .IMPORT \"modules/math.evo\" AS MATHLIB");
+
+        assertThat(matcher.group(1)).isNotNull();
+        assertThat(matcher.group(2)).isEqualTo("modules/math.evo");
+        assertThat(matcher.group(3)).isEqualTo("MATHLIB");
+    }
+
+    @Test
+    @Tag("unit")
+    void usingClausesSurviveBothWithAndWithoutTheMarker() {
+        Matcher plain = match(".IMPORT \"m.evo\" AS NAV USING MATHLIB AS ARITH");
+        assertThat(plain.group(1)).isNull();
+        assertThat(plain.group(4)).isEqualTo(" USING MATHLIB AS ARITH");
+
+        Matcher exported = match("EXPORT .IMPORT \"m.evo\" AS NAV USING MATHLIB AS ARITH USING B AS C");
+        assertThat(exported.group(1)).isNotNull();
+        assertThat(exported.group(4)).isEqualTo(" USING MATHLIB AS ARITH USING B AS C");
+    }
+
+    @Test
+    @Tag("unit")
+    void theDirectiveIsRecognisedInLowerCase() {
+        Matcher matcher = match("export .import \"m.evo\" as nav");
+
+        assertThat(matcher.group(1)).isNotNull();
+        assertThat(matcher.group(3)).isEqualTo("nav");
+    }
+
+    @Test
+    @Tag("unit")
+    void aWordMerelyStartingWithExportIsNotTheMarker() {
+        assertThat(PATTERN.matcher("EXPORTED .IMPORT \"m.evo\" AS NAV").matches()).isFalse();
+    }
+
+    @Test
+    @Tag("unit")
+    void theMarkerBelongsInFrontOfTheDirective() {
+        assertThat(PATTERN.matcher(".IMPORT EXPORT \"m.evo\" AS NAV").matches()).isFalse();
+    }
+}

--- a/src/test/java/org/evochora/compiler/module/PassedOnRequirementTest.java
+++ b/src/test/java/org/evochora/compiler/module/PassedOnRequirementTest.java
@@ -1,0 +1,142 @@
+package org.evochora.compiler.module;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.evochora.compiler.Compiler;
+import org.evochora.compiler.api.CompilationException;
+import org.evochora.compiler.api.ProgramArtifact;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.EnvironmentProperties;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies that a module can hand on a dependency it received itself.
+ * <p>
+ * A module declares with {@code .REQUIRE} that it needs something without saying which module that
+ * is; whoever imports it decides, through a {@code USING} clause. A module in the middle of such a
+ * chain has the same freedom to leave the choice open: what it received under one name it hands to
+ * its own import under another, so only the outermost caller decides what actually arrives at the
+ * bottom.
+ */
+class PassedOnRequirementTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Compiler compiler;
+
+    @BeforeAll
+    static void initInstructionSet() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        compiler = new Compiler();
+    }
+
+    @Test
+    @Tag("integration")
+    void aRequirementReceivedFromAboveCanBeHandedDownFurther() throws Exception {
+        // The module at the bottom needs a math module and does not care which one.
+        Files.writeString(tempDir.resolve("math.evo"), String.join("\n",
+                "EXPORT .PROC DOUBLE REF X",
+                "  ADDI X DATA:0",
+                "  RET",
+                ".ENDP",
+                ""));
+
+        Files.writeString(tempDir.resolve("bottom.evo"), String.join("\n",
+                ".REQUIRE \"math.evo\" AS MATH",
+                "EXPORT .PROC WORK REF X",
+                "  CALL MATH.DOUBLE REF X",
+                "  RET",
+                ".ENDP",
+                ""));
+
+        // The middle module leaves the choice open as well: it requires math and hands on what it
+        // was given, without importing a math module of its own.
+        Files.writeString(tempDir.resolve("middle.evo"), String.join("\n",
+                ".REQUIRE \"math.evo\" AS MATH",
+                ".IMPORT \"bottom.evo\" AS BOTTOM USING MATH AS MATH",
+                "EXPORT .PROC RUN REF X",
+                "  CALL BOTTOM.WORK REF X",
+                "  RET",
+                ".ENDP",
+                ""));
+
+        // Only the outermost module decides which math module reaches the bottom.
+        Files.writeString(tempDir.resolve("main.evo"), String.join("\n",
+                ".IMPORT \"math.evo\" AS M",
+                ".IMPORT \"middle.evo\" AS MIDDLE USING M AS MATH",
+                "START:",
+                "  SETI %DR0 DATA:1",
+                "  CALL MIDDLE.RUN REF %DR0",
+                ""));
+
+        assertThatCode(this::compileMain)
+                .as("MIDDLE hands the math module it received on to BOTTOM")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @Tag("integration")
+    void aUsingSourceThatIsNeitherImportedNorRequiredIsRejected() throws Exception {
+        Files.writeString(tempDir.resolve("bottom.evo"), String.join("\n",
+                ".REQUIRE \"math.evo\" AS MATH",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("main.evo"), String.join("\n",
+                ".IMPORT \"bottom.evo\" AS BOTTOM USING NOWHERE AS MATH",
+                "  NOP",
+                ""));
+
+        assertThatCode(this::compileMain)
+                .as("a name that is neither imported nor required cannot satisfy anything")
+                .isInstanceOf(CompilationException.class)
+                .hasMessageContaining("NOWHERE");
+    }
+
+    @Test
+    @Tag("integration")
+    void modulesThatImportEachOtherAreRejected() throws Exception {
+        // Handing a dependency on walks from the outermost module inwards, which terminates
+        // because the module graph is acyclic. That is not an assumption but a checked property:
+        // a cycle is caught while scanning, before any binding is resolved.
+        Files.writeString(tempDir.resolve("a.evo"), String.join("\n",
+                ".IMPORT \"b.evo\" AS B",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("b.evo"), String.join("\n",
+                ".IMPORT \"a.evo\" AS A",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("main.evo"), String.join("\n",
+                ".IMPORT \"a.evo\" AS START",
+                "  NOP",
+                ""));
+
+        assertThatCode(this::compileMain)
+                .as("two modules importing each other cannot be ordered")
+                .isInstanceOf(CompilationException.class)
+                .hasMessageContaining("Circular");
+    }
+
+    private ProgramArtifact compileMain() throws Exception {
+        Path mainFile = tempDir.resolve("main.evo");
+        return compiler.compile(
+                Files.readAllLines(mainFile),
+                mainFile.toAbsolutePath().toString(),
+                new EnvironmentProperties(new int[]{100, 100}, true));
+    }
+}

--- a/src/test/java/org/evochora/compiler/module/ReExportedImportResolutionTest.java
+++ b/src/test/java/org/evochora/compiler/module/ReExportedImportResolutionTest.java
@@ -1,0 +1,148 @@
+package org.evochora.compiler.module;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.evochora.compiler.Compiler;
+import org.evochora.compiler.api.CompilationException;
+import org.evochora.compiler.api.ProgramArtifact;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.EnvironmentProperties;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Verifies that a name reaches through a re-exported import.
+ * <p>
+ * A module may pass an import on to whoever imports it, written as {@code EXPORT .IMPORT}. A symbol
+ * behind such an import is then addressed through both levels — {@code MIDDLE.INNER.SYMBOL} — and
+ * resolution has to walk the chain, checking at each step that the import was in fact re-exported.
+ * Without the export the same name must stay unresolved, or the marker would decide nothing.
+ */
+class ReExportedImportResolutionTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Compiler compiler;
+
+    @BeforeAll
+    static void initInstructionSet() {
+        Instruction.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        compiler = new Compiler();
+    }
+
+    @Test
+    @Tag("integration")
+    void aSymbolBehindAReExportedImportResolvesThroughBothLevels() throws Exception {
+        writeModules("EXPORT .IMPORT \"inner.evo\" AS INNER");
+
+        assertThatCode(this::compileMain)
+                .as("MIDDLE re-exports INNER, so MIDDLE.INNER.TARGET names a known label")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @Tag("integration")
+    void withoutTheExportMarkerTheSameNameStaysUnresolved() throws Exception {
+        writeModules(".IMPORT \"inner.evo\" AS INNER");
+
+        assertThatCode(this::compileMain)
+                .as("MIDDLE keeps INNER to itself, so MIDDLE.INNER.TARGET names nothing")
+                .isInstanceOf(CompilationException.class)
+                .hasMessageContaining("TARGET");
+    }
+
+    @Test
+    @Tag("integration")
+    void aChainReachesThroughEveryLevelThatPassesItOn() throws Exception {
+        writeChain("EXPORT .IMPORT \"inner.evo\" AS INNER", "EXPORT .IMPORT \"middle.evo\" AS MIDDLE");
+
+        assertThatCode(this::compileOuter)
+                .as("every level passes its import on, so OUTER.MIDDLE.INNER.TARGET is reachable")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @Tag("integration")
+    void oneLevelWithoutTheMarkerEndsTheChain() throws Exception {
+        writeChain("EXPORT .IMPORT \"inner.evo\" AS INNER", ".IMPORT \"middle.evo\" AS MIDDLE");
+
+        assertThatCode(this::compileOuter)
+                .as("the outermost level keeps its import to itself, so the chain stops there")
+                .isInstanceOf(CompilationException.class)
+                .hasMessageContaining("TARGET");
+    }
+
+    /**
+     * Writes four modules for a two-step chain: outer refers through main and middle to inner.
+     */
+    private void writeChain(String middleImport, String mainImport) throws Exception {
+        Files.writeString(tempDir.resolve("inner.evo"), String.join("\n",
+                "EXPORT TARGET:",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("middle.evo"), String.join("\n",
+                middleImport,
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("main.evo"), String.join("\n",
+                mainImport,
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("outer.evo"), String.join("\n",
+                ".IMPORT \"main.evo\" AS OUTER",
+                "  JMPI OUTER.MIDDLE.INNER.TARGET",
+                ""));
+    }
+
+    private ProgramArtifact compileOuter() throws Exception {
+        Path outerFile = tempDir.resolve("outer.evo");
+        return compiler.compile(
+                Files.readAllLines(outerFile),
+                outerFile.toAbsolutePath().toString(),
+                new EnvironmentProperties(new int[]{100, 100}, true));
+    }
+
+    /**
+     * Writes three modules: main refers through middle to inner, and middle imports inner with the
+     * given directive — once with the export marker, once without.
+     */
+    private void writeModules(String middleImport) throws Exception {
+        Files.writeString(tempDir.resolve("inner.evo"), String.join("\n",
+                "EXPORT TARGET:",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("middle.evo"), String.join("\n",
+                middleImport,
+                "EXPORT OWN:",
+                "  NOP",
+                ""));
+
+        Files.writeString(tempDir.resolve("main.evo"), String.join("\n",
+                ".IMPORT \"middle.evo\" AS MIDDLE",
+                "  JMPI MIDDLE.INNER.TARGET",
+                ""));
+    }
+
+    private ProgramArtifact compileMain() throws Exception {
+        Path mainFile = tempDir.resolve("main.evo");
+        return compiler.compile(
+                Files.readAllLines(mainFile),
+                mainFile.toAbsolutePath().toString(),
+                new EnvironmentProperties(new int[]{100, 100}, true));
+    }
+}

--- a/src/test/java/org/evochora/compiler/module/UsingClauseIntegrationTest.java
+++ b/src/test/java/org/evochora/compiler/module/UsingClauseIntegrationTest.java
@@ -117,7 +117,7 @@ class UsingClauseIntegrationTest {
         DiagnosticsEngine diagnostics = compileThroughSemantics(mainSource, mainPath);
 
         assertThat(diagnostics.hasErrors()).isTrue();
-        assertErrorContaining(diagnostics, "UNKNOWN", "not a known import alias");
+        assertErrorContaining(diagnostics, "UNKNOWN", "neither an import nor a requirement");
     }
 
     @Test


### PR DESCRIPTION
Fixes #131.

The issue reports that `ModuleScope.importExported` is never written, so multi-level name resolution always fails. That is true, and it turned out to be the last of three places where the same marker gets lost — and next to it sits a second gap in the opposite direction, which this PR closes as well.

## What the language is supposed to do

Two directions, and neither is limited to one level:

**Downwards.** A module names what it needs with `.REQUIRE` without saying which module that is; its importer decides with `USING`. A module in the middle may keep that freedom and hand on what it was given.

**Upwards.** A module marks its own import with `EXPORT`, and whoever imports it may then use it — `MIDDLE.INNER.NAME` — without placing that code a second time.

The upward direction existed in syntax, parser and AST but had no effect. The downward one stopped after a single level.

## Upwards: the marker never arrived

`EXPORT .IMPORT` is documented on `ImportNode` and read by the parser (`context.isExported()`), but three stations dropped it:

1. The dependency scanner matched `^\.IMPORT` only, so a marked import was never scanned and its module never loaded. The compilation failed with "Module tokens not found" long before any name was resolved.
2. `ImportDependencyInfo` — the record the scanner produces — had no field for it.
3. `ImportModuleSetupHandler` wrote the import into the module scope without it.

`SymbolTable.resolveMultiLevel` then asked for a flag nobody had set, took the early return every time, and the recursive call below it was unreachable.

The marker now travels the whole way. Each level decides for its own import: a chain reaches as far as every step passes it on, and a step without the prefix ends it there — which is exactly what the existing resolution code was written for.

Both places describing this directive's syntax — the scanner's regular expression and the parser handler — now say that the other exists. Their drift is what kept the marked form from ever loading.

## Downwards: a requirement could not travel further than one level

`USING` accepted only a module the current one had **imported**. A module that received a dependency itself could not hand it on, so every intermediate level had to settle on a concrete module and lost the interchangeability `.REQUIRE` exists for.

A `USING` source is now either an import or a requirement of the current module — in the analysis that validates it and in the setup that wires it. `SymbolTable.resolveMultiLevel` has consulted both maps all along; the two had simply drifted apart.

**This needed one more change than expected.** Binding resolution ran over the dependency order, leaves first. A module can only hand on what it has already been given, so pass 3 now walks from the outermost module inwards. Without that the extension does not work — the mutation probe shows it: reverse the order back and only the pass-on case fails.

## On cycles

No new guard, because none could fire. `resolveMultiLevel` shortens the remaining name at every step and therefore terminates structurally; passing on is one walk per module, not a recursion. For a chain to lead back, the module graph would have to contain a cycle — and `DependencyScanner` rejects that during scanning, before any binding is resolved. A test now holds that property in place: two modules importing each other are rejected with "Circular".

## Verification

- **Seven new test cases.** For the upward direction: resolves with the marker, stays unresolved without it, reaches through a two-step chain, and stops at a level that omits the marker. For the downward direction: a requirement received from above is handed on, a `USING` source that is neither import nor requirement is rejected, and a module cycle is caught. Both negative cases assert that compilation fails on the *name*, not on a loading error.
- **Mutation probes, both directions.** Removing the line that writes the marker fails exactly the two positive re-export cases; reversing the resolution order back fails exactly the pass-on case. Neither test can go green by accident.
- **All four assembly programs compile**: the three examples and the primordial organism.
- Full build green: 2365 tests, 0 failures, PMD clean.

## Documentation and example

`ASSEMBLY_SPEC.md` gives `.IMPORT` its optional `EXPORT` prefix, in the same short form as `.DEFINE` and `.PROC`. The module example gains `modules/navigation.evo` and shows both directions in a program that runs: math chosen once at the top and handed down through two levels to the module that asked for one without naming it, movement handed back up and reached as `NAV.MOVE`.

## Two existing tests changed

They asserted the wording "not a known import alias". The case is still rejected; the condition is now a different one and says so: "neither an import nor a requirement of the current module".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xceL1HuBDDxYLkA1BB3cE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `EXPORT .IMPORT`, enabling access to re-exported modules across multiple layers.
  * Expanded `USING` to pass requirements through intermediate modules.
  * Added navigation examples demonstrating chained module access and re-exported functionality.

* **Bug Fixes**
  * Improved dependency validation, diagnostics, and binding resolution for chained imports.

* **Documentation**
  * Documented exported imports, qualified access, and transitive dependency wiring.

* **Tests**
  * Added coverage for re-exports, transitive requirements, invalid bindings, circular imports, import syntax, and example compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->