### PR TITLE
Have SonarQube Cloud read the code beside the build, not inside it

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,59 @@
+name: Sonar Analysis
+
+# Static analysis by SonarQube Cloud, kept in its own workflow so it runs beside the build job
+# instead of after it. Nothing here feeds back into the build: the job reports to the Sonar
+# dashboard and decorates the pull request, and the time it takes never adds to the wait for
+# "Build and Test".
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# Pull requests share one group, so a quick second push discards the run its predecessor
+# started — the token writes to the Sonar project, and a queue of stale runs would keep
+# overwriting each other's results. A push to main has no pull request number and falls back to
+# the run id, which groups with nothing, so those analyses all complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  sonar:
+    name: SonarQube Cloud
+    runs-on: ubuntu-latest
+    # Pull requests from forks receive no secrets, so SONAR_TOKEN would be empty and the analysis
+    # would fail for reasons unrelated to the contribution. Such runs are skipped instead.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Sonar derives the new-code period from the commit history, which a shallow clone lacks.
+          fetch-depth: 0
+          # The analysis only reads the working tree; leaving the token behind in .git/config would
+          # hand it to every process in the job.
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      # Compiled classes are what the Java analyser reads; the tests are not run, because the
+      # analysis reports no coverage. See the sonar block in build.gradle.kts.
+      - name: Run Sonar analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew compileJava sonar --no-daemon --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("com.google.protobuf") version "0.9.6"
     id("me.champeau.jmh") version "0.7.3"
     id("pmd")
+    id("org.sonarqube") version "7.5.0.8588"
 }
 
 java {
@@ -434,6 +435,23 @@ pmd {
 tasks.withType<Pmd>().configureEach {
     // Generated protobuf sources: nobody edits them, and the generator will not follow these rules.
     exclude("**/org/evochora/datapipeline/api/contracts/**")
+}
+
+// Analysis by SonarQube Cloud. The `sonar` task is deliberately not wired into `build` or `check`:
+// it uploads to an external service and needs a token, so it runs only where it is asked for —
+// the CI workflow, or an explicit local `./gradlew sonar`.
+//
+// Coverage is not reported here. The build already gates line coverage through
+// jacocoTestCoverageVerification, and Sonar does not measure coverage itself; it would only import
+// the same JaCoCo report. Leaving it out keeps the analysis independent of a test run.
+sonar {
+    properties {
+        property("sonar.projectKey", "evochora_evochora")
+        property("sonar.organization", "evochora")
+        property("sonar.host.url", "https://sonarcloud.io")
+        // Generated protobuf sources: nobody edits them, and the generator will not follow these rules.
+        property("sonar.exclusions", "**/org/evochora/datapipeline/api/contracts/**")
+    }
 }
 
 // Javadoc that no longer resolves — a link to a method that was renamed, markup that does not


### PR DESCRIPTION
## What this adds

The build already gates what it can decide on its own: dead code via PMD, javadoc that no longer resolves, line coverage, and — since #147 — the coverage of the lines a change touches. What it does not look at is the wider set of code smells, concurrency mistakes and resource handling that a reviewer has had to catch by reading.

SonarQube Cloud analyses exactly that. For a public repository it is free with no size limit, and it writes its findings onto the pull request.

## What it costs

**Nothing in `gradlew build`.** The `sonar` task hangs off neither `build` nor `check` — verified with `--dry-run`: zero sonar tasks appear in the `build` graph, and `compileJava sonar` pulls in no test run.

**Nothing in the wait for Build & Test.** The analysis runs in its own workflow, started at the same time rather than after. How long it takes is its own business; this pull request is the first run, so the figure is not known yet. Until it is, the check should not be a required one.

## Deliberate omissions

**Coverage is not reported to Sonar.** Sonar does not measure coverage itself — it imports a JaCoCo report, the same numbers this build already gates on. Asking for it would mean running the tests a second time inside the analysis job to produce a report that already exists.

**Generated protobuf sources are excluded**, for the same reason PMD skips them: nobody edits them and the generator will not follow these rules.

**Fork pull requests are skipped, not failed.** They run with a read-only token, so the analysis could not upload its results.

## Security

No new third-party action: because the analysis goes through the Gradle plugin, the workflow needs only `actions/checkout` and `actions/setup-java`, both already used elsewhere in this repository and pinned to the same commits. `permissions: {}` at workflow level and `contents: read` on the job, `persist-credentials: false`, no `run:` block interpolating a value, and the token reaches only the one step that needs it.

`fetch-depth: 0` is required here — Sonar derives its new-code period from the commit history, which a shallow clone lacks.

## Setup already done

The OSS organisation exists, `SONAR_TOKEN` is in place, and the keys in `build.gradle.kts` match what SonarCloud generated (`evochora` / `evochora_evochora`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ios1Tu9CjytTvvth6ayCm