### PR TITLE
Resolve procedure names and genome colours in the visualizer

### DIFF
--- a/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/IOrganismDataReader.java
@@ -1,6 +1,7 @@
 package org.evochora.datapipeline.api.resources.database;
 
 import org.evochora.datapipeline.api.resources.database.dto.LineageMutations;
+import org.evochora.datapipeline.utils.LabelNamespaceMask;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickDetails;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickSummary;
 
@@ -118,6 +119,28 @@ public interface IOrganismDataReader {
      */
     List<LineageMutations> readLineageMutations(int organismId)
             throws SQLException, OrganismNotFoundException;
+
+    /**
+     * The label namespace the body of the organism at the head of a chain stands in.
+     * <p>
+     * Every newborn's LABEL and LABELREF values are XOR-masked at birth, cumulatively down the
+     * lineage, so a label value in a body is the compiled value XORed with this mask. Anything that
+     * holds a body's label value against the program it descends from — a procedure name, a jump
+     * target, a comparison with the compiled code — has to take the mask out first.
+     * <p>
+     * It is a default method rather than something each implementation works out for itself,
+     * because getting it wrong is silent: a mask that is zero when it should not be resolves every
+     * label of every descendant to nothing, which looks exactly like an organism that has none.
+     * Composing it from the chain an implementation already returns leaves one definition of the
+     * rule and nothing for a new implementation to remember.
+     *
+     * @param chain The chain as {@link #readLineageMutations(int)} returns it, the organism first
+     * @return The composed mask, zero for an ancestry that never rewrote a label
+     * @throws IllegalStateException if a recorded label mask carries no mask value
+     */
+    default int labelNamespaceMaskOf(List<LineageMutations> chain) {
+        return LabelNamespaceMask.ofChain(chain.stream().map(LineageMutations::events).toList());
+    }
 }
 
 

--- a/src/main/java/org/evochora/datapipeline/api/resources/database/dto/InstructionArgumentView.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/dto/InstructionArgumentView.java
@@ -14,7 +14,9 @@ public final class InstructionArgumentView {
 
     // For REGISTER type
     /**
-     * Register ID (e.g., 0 for %DR0).
+     * Register id in the whole register space, the same id every bank is addressed by: 0 for
+     * {@code %DR0}, 256 for {@code %LR0}, 512 for {@code %PDR0}. The index within a bank is the id
+     * minus that bank's base, which {@link #registerType} names.
      * Only present for REGISTER type.
      */
     public final Integer registerId;
@@ -26,10 +28,11 @@ public final class InstructionArgumentView {
     public final RegisterValueView registerValue;
 
     /**
-     * Register type name: "DR", "PDR", "FDR", or "LR".
+     * Name of the bank the register belongs to, one of {@code RegisterBank}'s names, or "UNKNOWN"
+     * when the cell holds a value that is no register id at all, which is what an overwritten
+     * operand looks like. It names the bank {@link #registerId} falls into, so a reader need not
+     * derive it from the id.
      * Only present for REGISTER type.
-     * This is needed because DR and LR share the same index range (0-3),
-     * so we need to explicitly indicate which register type it is.
      */
     public final String registerType;
 
@@ -80,9 +83,9 @@ public final class InstructionArgumentView {
     /**
      * Creates an argument view for a REGISTER type.
      *
-     * @param registerId    Register ID (e.g., 0 for %DR0)
+     * @param registerId    Register id in the whole register space, not the index within its bank
      * @param registerValue Register value resolved from organism state
-     * @param registerType  Register type: "DR", "PDR", "FDR", or "LR"
+     * @param registerType  Name of the bank the id falls into, or "UNKNOWN" for no register id
      * @return InstructionArgumentView for REGISTER type
      */
     public static InstructionArgumentView register(int registerId, RegisterValueView registerValue, String registerType) {

--- a/src/main/java/org/evochora/datapipeline/api/resources/database/dto/OrganismStaticInfo.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/dto/OrganismStaticInfo.java
@@ -3,7 +3,8 @@ package org.evochora.datapipeline.api.resources.database.dto;
 import java.util.List;
 
 /**
- * Static organism metadata as indexed in the organisms table.
+ * What does not change over an organism's life: the values the organisms table holds for it, and
+ * the label namespace composed from the births of its ancestry.
  */
 public final class OrganismStaticInfo {
 
@@ -21,25 +22,37 @@ public final class OrganismStaticInfo {
     public final int[] initialPosition;
     /** Ancestry chain: direct parent first, oldest ancestor last. Empty for initial organisms. */
     public final List<LineageEntry> lineage;
+    /**
+     * The label namespace this organism's body stands in: every LABEL and LABELREF value in it is
+     * the value the program was compiled with, XORed with this mask. Zero for an organism whose
+     * ancestry never rewrote a label, so a reader may apply it unconditionally. It is the mask
+     * itself, not its inverse, because XOR is its own inverse: the same value turns a compiled
+     * label value into this body's and back.
+     */
+    public final int labelNamespaceMask;
 
     /**
      * Constructs a static organism view from the values held in the organisms table.
      *
-     * @param parentId        Id of the parent organism, or {@code null} if the organism has none.
-     * @param birthTick       Simulation tick at which the organism came into existence.
-     * @param programId       Id of the program artifact the organism was born with.
-     * @param initialPosition Coordinates the organism's instruction pointer started at.
-     * @param lineage         Ancestry chain, direct parent first; empty for initial organisms.
+     * @param parentId           Id of the parent organism, or {@code null} if the organism has none.
+     * @param birthTick          Simulation tick at which the organism came into existence.
+     * @param programId          Id of the program artifact the organism was born with.
+     * @param initialPosition    Coordinates the organism's instruction pointer started at.
+     * @param lineage            Ancestry chain, direct parent first; empty for initial organisms.
+     * @param labelNamespaceMask Composed label mask of every birth of the ancestry, this organism's
+     *                           own included; zero if no birth rewrote a label.
      */
     public OrganismStaticInfo(Integer parentId,
                               long birthTick,
                               String programId,
                               int[] initialPosition,
-                              List<LineageEntry> lineage) {
+                              List<LineageEntry> lineage,
+                              int labelNamespaceMask) {
         this.parentId = parentId;
         this.birthTick = birthTick;
         this.programId = programId;
         this.initialPosition = initialPosition;
         this.lineage = lineage;
+        this.labelNamespaceMask = labelNamespaceMask;
     }
 }

--- a/src/main/java/org/evochora/datapipeline/api/resources/database/dto/ProcFrameView.java
+++ b/src/main/java/org/evochora/datapipeline/api/resources/database/dto/ProcFrameView.java
@@ -9,8 +9,9 @@ public final class ProcFrameView {
 
     /**
      * Name of the called procedure, resolved from the frame's label hash via the run's program
-     * artifact. Empty when the hash is not in that artifact, which happens for a call target
-     * created by code mutation; callers distinguish named from unnamed frames by emptiness.
+     * artifact, after the organism's label namespace has been taken out of the hash. Empty when the
+     * artifact holds no such label even then, which happens for a call target created by code
+     * mutation; callers distinguish named from unnamed frames by emptiness.
      */
     public final String procName;
     /** Absolute coordinates execution resumes at once the procedure returns. */

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
@@ -460,7 +460,9 @@ public class H2DatabaseReader implements IDatabaseReader {
      * @param organismId The organism to describe
      * @return The static view, or null if the organism has no row
      * @throws SQLException if a query fails
-     * @throws OrganismNotFoundException if the ancestry walk finds no row for the organism
+     * @throws OrganismNotFoundException if the ancestry walk finds no row for the organism, which
+     *         the lookup above has already answered with null unless the row was removed between
+     *         the two queries
      */
     private OrganismStaticInfo readOrganismStaticInfo(int organismId)
             throws SQLException, OrganismNotFoundException {

--- a/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/H2DatabaseReader.java
@@ -264,19 +264,8 @@ public class H2DatabaseReader implements IDatabaseReader {
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     int id = rs.getInt("organism_id");
-                    byte[] storedEvents = rs.getBytes("birth_mutations");
-                    StoredMutationEvents events;
-                    if (storedEvents == null) {
-                        events = StoredMutationEvents.getDefaultInstance();
-                    } else {
-                        try {
-                            events = StoredMutationEvents.parseFrom(storedEvents);
-                        } catch (InvalidProtocolBufferException e) {
-                            throw new SQLException(
-                                "Birth mutations of organism " + id + " of run " + runId
-                                + " are not a readable message", e);
-                        }
-                    }
+                    StoredMutationEvents events =
+                        decodeBirthMutations(id, rs.getBytes("birth_mutations"));
                     long parentGenome = rs.getLong("parent_genome_hash");
                     Long parentGenomeHash = rs.wasNull() ? null : parentGenome;
                     chain.add(new LineageMutations(
@@ -335,7 +324,8 @@ public class H2DatabaseReader implements IDatabaseReader {
         
         // Convert OrganismState to OrganismRuntimeView (includes both last and next instruction from protobuf)
         Map<Integer, String> labelValueToName = extractLabelValueToName(metadata, orgState.getProgramId());
-        OrganismRuntimeView state = convertOrganismStateToRuntimeView(orgState, envDimensions, labelValueToName);
+        OrganismRuntimeView state = convertOrganismStateToRuntimeView(
+                orgState, envDimensions, labelValueToName, staticInfo.labelNamespaceMask);
 
         return new OrganismTickDetails(organismId, tickNumber, staticInfo, state);
     }
@@ -348,13 +338,16 @@ public class H2DatabaseReader implements IDatabaseReader {
      *
      * @param orgState OrganismState Protobuf object
      * @param envDimensions Environment dimensions for instruction resolution
+     * @param labelValueToName Compiled label values to names, from the run's program artifact
+     * @param labelNamespaceMask The organism's label namespace, which its own label values stand in
      * @return OrganismRuntimeView DTO
      * @throws SQLException if conversion fails
      */
     private OrganismRuntimeView convertOrganismStateToRuntimeView(
             org.evochora.datapipeline.api.contracts.OrganismState orgState,
             int[] envDimensions,
-            Map<Integer, String> labelValueToName) throws SQLException {
+            Map<Integer, String> labelValueToName,
+            int labelNamespaceMask) throws SQLException {
         
         int energy = orgState.getEnergy();
         int[] ip = OrganismStateConverter.vectorToArray(orgState.getIp());
@@ -389,13 +382,13 @@ public class H2DatabaseReader implements IDatabaseReader {
         java.util.List<org.evochora.datapipeline.api.resources.database.dto.ProcFrameView> callStack = 
                 new java.util.ArrayList<>();
         for (var frame : orgState.getCallStackList()) {
-            callStack.add(OrganismStateConverter.convertProcFrame(frame, labelValueToName));
+            callStack.add(OrganismStateConverter.convertProcFrame(frame, labelValueToName, labelNamespaceMask));
         }
         
         java.util.List<org.evochora.datapipeline.api.resources.database.dto.ProcFrameView> failureStack = 
                 new java.util.ArrayList<>();
         for (var frame : orgState.getFailureCallStackList()) {
-            failureStack.add(OrganismStateConverter.convertProcFrame(frame, labelValueToName));
+            failureStack.add(OrganismStateConverter.convertProcFrame(frame, labelValueToName, labelNamespaceMask));
         }
         
         // Resolve instruction
@@ -456,69 +449,75 @@ public class H2DatabaseReader implements IDatabaseReader {
         );
     }
 
-    private OrganismStaticInfo readOrganismStaticInfo(int organismId) throws SQLException {
+    /**
+     * Reads what does not change over an organism's life.
+     * <p>
+     * The ancestry is read through {@link #readLineageMutations(int)}, which walks the chain once
+     * and brings each birth's recorded events along. That one walk answers both things this view
+     * needs from the ancestry: the chain itself, and the label namespace the organism's body
+     * stands in, which {@link #labelNamespaceMaskOf} composes from those births.
+     *
+     * @param organismId The organism to describe
+     * @return The static view, or null if the organism has no row
+     * @throws SQLException if a query fails
+     * @throws OrganismNotFoundException if the ancestry walk finds no row for the organism
+     */
+    private OrganismStaticInfo readOrganismStaticInfo(int organismId)
+            throws SQLException, OrganismNotFoundException {
         String sql = """
             SELECT parent_id, birth_tick, program_id, initial_position
             FROM organisms
             WHERE organism_id = ?
             """;
 
+        Integer parentId;
+        long birthTick;
+        String programId;
+        int[] initialPos;
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setInt(1, organismId);
             try (ResultSet rs = stmt.executeQuery()) {
                 if (!rs.next()) {
                     return null;
                 }
-
-                Integer parentId = rs.getObject("parent_id") != null
-                        ? rs.getInt("parent_id")
-                        : null;
-                long birthTick = rs.getLong("birth_tick");
-                String programId = rs.getString("program_id");
-                byte[] initialPosBytes = rs.getBytes("initial_position");
-                int[] initialPos = OrganismStateConverter.decodeVector(initialPosBytes);
-
-                List<LineageEntry> lineage = readLineage(organismId);
-                return new OrganismStaticInfo(parentId, birthTick, programId, initialPos, lineage);
+                parentId = rs.getObject("parent_id") != null ? rs.getInt("parent_id") : null;
+                birthTick = rs.getLong("birth_tick");
+                programId = rs.getString("program_id");
+                initialPos = OrganismStateConverter.decodeVector(rs.getBytes("initial_position"));
             }
         }
+
+        // The organism itself is the first entry of the chain; the lineage names only its ancestors
+        List<LineageMutations> chain = readLineageMutations(organismId);
+        List<LineageEntry> lineage = new ArrayList<>(chain.size() - 1);
+        for (LineageMutations ancestor : chain.subList(1, chain.size())) {
+            lineage.add(new LineageEntry(ancestor.organismId(), ancestor.genomeHash()));
+        }
+        int labelNamespaceMask = labelNamespaceMaskOf(chain);
+
+        return new OrganismStaticInfo(parentId, birthTick, programId, initialPos, lineage,
+                labelNamespaceMask);
     }
 
     /**
-     * Reads the ancestry chain for an organism via recursive CTE.
-     * Returns direct parent first, oldest ancestor last. Empty list for initial organisms.
+     * Reads the birth mutations of one organism from the column they are stored in.
      *
-     * @param organismId The organism to trace ancestry for.
-     * @return Ancestry chain (never null).
-     * @throws SQLException if database query fails.
+     * @param organismId The organism the row belongs to, for the error message
+     * @param stored     The stored message, null for an organism no mutation plugin touched
+     * @return The events, empty when the column holds nothing
+     * @throws SQLException if the column does not hold a readable message
      */
-    private List<LineageEntry> readLineage(int organismId) throws SQLException {
-        String sql = """
-            WITH RECURSIVE ancestors(org_id, depth) AS (
-                SELECT parent_id, 1
-                FROM organisms WHERE organism_id = ?
-                UNION ALL
-                SELECT o.parent_id, a.depth + 1
-                FROM ancestors a
-                JOIN organisms o ON o.organism_id = a.org_id
-                WHERE o.parent_id IS NOT NULL
-            )
-            SELECT o.organism_id, o.genome_hash
-            FROM ancestors a
-            JOIN organisms o ON o.organism_id = a.org_id
-            ORDER BY a.depth ASC
-            """;
-
-        List<LineageEntry> lineage = new ArrayList<>();
-        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setInt(1, organismId);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    lineage.add(new LineageEntry(rs.getInt("organism_id"), rs.getLong("genome_hash")));
-                }
-            }
+    private StoredMutationEvents decodeBirthMutations(int organismId, byte[] stored)
+            throws SQLException {
+        if (stored == null) {
+            return StoredMutationEvents.getDefaultInstance();
         }
-        return lineage;
+        try {
+            return StoredMutationEvents.parseFrom(stored);
+        } catch (InvalidProtocolBufferException e) {
+            throw new SQLException("Birth mutations of organism " + organismId + " of run " + runId
+                + " are not a readable message", e);
+        }
     }
 
     @Override

--- a/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
@@ -125,6 +125,38 @@ public final class OrganismStateConverter {
     }
     
     /**
+     * Makes sure the cells of an instruction's next operand were recorded before they are read.
+     * <p>
+     * How many cells an instruction occupies and which operands it has are built from one list at
+     * registration: {@code Instruction} derives the length table and the signature from the same
+     * operand sources. The runtime reads cells by that length and fills every one of them, a cell
+     * outside a bounded world included. A record that is shorter than the signature therefore does
+     * not describe an organism whose code was overwritten — its cells would be recorded with other
+     * contents, not with fewer entries — but a disagreement between those two derivations, which
+     * is a defect of ours.
+     * <p>
+     * Failing here rather than resolving the operands that happen to be present keeps such a record
+     * from reaching a reader as a plausible-looking instruction with one operand quietly missing.
+     *
+     * @param argIndex      Index of the next unread cell
+     * @param needed        Number of cells the current operand occupies
+     * @param rawArguments  The instruction's recorded argument cells
+     * @param opcodeId      Opcode of the instruction, for the message
+     * @param opcodeName    Name of the instruction, for the message
+     * @param argumentCount Number of operands the signature declares, for the message
+     * @throws IllegalStateException if the record ends before the operand does
+     */
+    private static void requireArgumentCells(int argIndex, int needed, List<Integer> rawArguments,
+                                             int opcodeId, String opcodeName, int argumentCount) {
+        if (argIndex + needed > rawArguments.size()) {
+            throw new IllegalStateException(String.format(
+                "Instruction %d (%s) declares %d operands, but its recorded cells end after %d:"
+                + " the operand at cell %d needs %d more.",
+                opcodeId, opcodeName, argumentCount, rawArguments.size(), argIndex, needed));
+        }
+    }
+
+    /**
      * Converts a Protobuf ProcFrame to a ProcFrameView DTO.
      * <p>
      * The procedure name is resolved from the frame's label hash. The hash stands in the
@@ -278,33 +310,29 @@ public final class OrganismStateConverter {
             if (argType == org.evochora.runtime.isa.InstructionArgumentType.REGISTER) {
                 // REGISTER: Extract register ID from raw argument
                 argumentTypesList.add("REGISTER");
-                if (argIndex < rawArguments.size()) {
-                    int rawArg = rawArguments.get(argIndex);
-                    Molecule molecule = Molecule.fromInt(rawArg);
-                    int registerId = molecule.toScalarValue();
-                    
-                    // Determine register type via RegisterBank lookup
-                    RegisterBank regBank = RegisterBank.forId(registerId);
-                    String registerType = regBank != null ? regBank.name() : "UNKNOWN";
-                    
-                    // Resolve register value: use value BEFORE execution (null if unavailable)
-                    RegisterValueView registerValue = (registerValuesBefore != null)
-                        ? registerValuesBefore.get(registerId)
-                        : null;
-                    
-                    resolvedArgs.add(InstructionArgumentView.register(registerId, registerValue, registerType));
-                    argIndex++;
-                }
+                requireArgumentCells(argIndex, 1, rawArguments, opcodeId, opcodeName, argTypes.size());
+                int rawArg = rawArguments.get(argIndex);
+                Molecule molecule = Molecule.fromInt(rawArg);
+                int registerId = molecule.toScalarValue();
+
+                // A cell that holds no valid register id names no bank, and the view says so: the
+                // operand was overwritten, and a reader is meant to see that
+                RegisterBank regBank = RegisterBank.forId(registerId);
+                String registerType = regBank != null ? regBank.name() : "UNKNOWN";
+
+                // Resolve register value: use value BEFORE execution (null if unavailable)
+                RegisterValueView registerValue = (registerValuesBefore != null)
+                    ? registerValuesBefore.get(registerId)
+                    : null;
+
+                resolvedArgs.add(InstructionArgumentView.register(registerId, registerValue, registerType));
+                argIndex++;
             } else if (argType == org.evochora.runtime.isa.InstructionArgumentType.LOCATION_REGISTER) {
                 // LOCATION_REGISTER: Extract register ID from raw argument
-                argumentTypesList.add("REGISTER"); // Frontend zeigt als REGISTER mit registerType="LR"
-                if (argIndex >= rawArguments.size()) {
-                    throw new IllegalStateException(
-                        String.format("LOCATION_REGISTER argument missing for instruction %d (%s). " +
-                            "Expected %d arguments but only %d available in rawArguments.",
-                            opcodeId, opcodeName, argTypes.size(), rawArguments.size()));
-                }
-                
+                // A location register reaches the view as a REGISTER whose registerType names its bank
+                argumentTypesList.add("REGISTER");
+                requireArgumentCells(argIndex, 1, rawArguments, opcodeId, opcodeName, argTypes.size());
+
                 int rawArg = rawArguments.get(argIndex);
                 Molecule molecule = Molecule.fromInt(rawArg);
                 int registerId = molecule.toScalarValue();
@@ -323,47 +351,43 @@ public final class OrganismStateConverter {
             } else if (argType == org.evochora.runtime.isa.InstructionArgumentType.LITERAL) {
                 // LITERAL: Decode molecule type and value (shown as IMMEDIATE in view)
                 argumentTypesList.add("IMMEDIATE");
-                if (argIndex < rawArguments.size()) {
-                    int rawArg = rawArguments.get(argIndex);
-                    Molecule molecule = Molecule.fromInt(rawArg);
-                    int typeId = molecule.type();
-                    String moleculeType = MoleculeTypeRegistry.typeToName(typeId);
-                    int value = molecule.toScalarValue();
-                    
-                    resolvedArgs.add(InstructionArgumentView.immediate(rawArg, moleculeType, value));
-                    argIndex++;
-                }
+                requireArgumentCells(argIndex, 1, rawArguments, opcodeId, opcodeName, argTypes.size());
+                int rawArg = rawArguments.get(argIndex);
+                Molecule molecule = Molecule.fromInt(rawArg);
+                String moleculeType = MoleculeTypeRegistry.typeToName(molecule.type());
+                int value = molecule.toScalarValue();
+
+                resolvedArgs.add(InstructionArgumentView.immediate(rawArg, moleculeType, value));
+                argIndex++;
             } else if (argType == org.evochora.runtime.isa.InstructionArgumentType.VECTOR) {
                 // VECTOR: Group multiple arguments into int[] array
                 argumentTypesList.add("VECTOR");
-                int dims = envDimensions != null ? envDimensions.length : 2;
+                int dims = envDimensions.length;
+                requireArgumentCells(argIndex, dims, rawArguments, opcodeId, opcodeName, argTypes.size());
                 int[] components = new int[dims];
-                boolean hasComponents = false;
-                
-                for (int dim = 0; dim < dims && argIndex < rawArguments.size(); dim++) {
-                    int rawArg = rawArguments.get(argIndex);
-                    Molecule molecule = Molecule.fromInt(rawArg);
-                    components[dim] = molecule.toScalarValue();
-                    hasComponents = true;
+                for (int dim = 0; dim < dims; dim++) {
+                    components[dim] = Molecule.fromInt(rawArguments.get(argIndex)).toScalarValue();
                     argIndex++;
                 }
-                
-                if (hasComponents) {
-                    resolvedArgs.add(InstructionArgumentView.vector(components));
-                }
+                resolvedArgs.add(InstructionArgumentView.vector(components));
             } else if (argType == org.evochora.runtime.isa.InstructionArgumentType.LABEL) {
                 // LABEL: Single scalar hash value (20-bit) since fuzzy jumps refactoring
                 // Formatted like IMMEDIATE with molecule type (typically DATA)
                 argumentTypesList.add("LABEL");
-                if (argIndex < rawArguments.size()) {
-                    int rawArg = rawArguments.get(argIndex);
-                    Molecule molecule = Molecule.fromInt(rawArg);
-                    int typeId = molecule.type();
-                    String moleculeType = MoleculeTypeRegistry.typeToName(typeId);
-                    int hashValue = molecule.toScalarValue();
-                    resolvedArgs.add(InstructionArgumentView.label(rawArg, moleculeType, hashValue));
-                    argIndex++;
-                }
+                requireArgumentCells(argIndex, 1, rawArguments, opcodeId, opcodeName, argTypes.size());
+                int rawArg = rawArguments.get(argIndex);
+                Molecule molecule = Molecule.fromInt(rawArg);
+                String moleculeType = MoleculeTypeRegistry.typeToName(molecule.type());
+                int hashValue = molecule.toScalarValue();
+                resolvedArgs.add(InstructionArgumentView.label(rawArg, moleculeType, hashValue));
+                argIndex++;
+            } else {
+                // An operand kind the instruction set declares and this conversion does not know
+                // would leave a gap between argumentTypes and the resolved arguments, and a reader
+                // comparing the two would read that gap as something the organism did
+                throw new IllegalStateException(String.format(
+                    "Instruction %d (%s) has an operand of kind %s, which this conversion does not"
+                    + " know.", opcodeId, opcodeName, argType));
             }
         }
         

--- a/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
@@ -127,21 +127,30 @@ public final class OrganismStateConverter {
     /**
      * Converts a Protobuf ProcFrame to a ProcFrameView DTO.
      * <p>
-     * The procedure name is resolved from the frame's label hash. A hash the map does not contain
-     * yields an empty name, and that is the correct result rather than a fallback: an organism
-     * inherits its program ID from its ancestor while its code mutates, so a call may target a hash
-     * the original program never held. The name must never be replaced by a placeholder — callers
-     * distinguish named from unnamed frames by emptiness.
+     * The procedure name is resolved from the frame's label hash. The hash stands in the
+     * organism's own label namespace, which is why the mask turns it back into the value the
+     * program was compiled with before the artifact is asked; without that step only a founding
+     * organism would ever resolve a name.
+     * <p>
+     * A hash the map does not contain even then yields an empty name, and that is the correct
+     * result rather than a fallback: an organism inherits its program ID from its ancestor while
+     * its code mutates, so a call may target a hash the original program never held. The name must
+     * never be replaced by a placeholder — callers distinguish named from unnamed frames by
+     * emptiness.
      *
      * @param frame The Protobuf ProcFrame
      * @param labelValueToName Label hash to procedure name, from the run's program artifact;
      *                         may be empty, in which case every name is empty
+     * @param labelNamespaceMask The organism's label namespace, from its static info; zero for an
+     *                           ancestry that never rewrote a label
      * @return ProcFrameView DTO
      */
     public static ProcFrameView convertProcFrame(
             org.evochora.datapipeline.api.contracts.ProcFrame frame,
-            Map<Integer, String> labelValueToName) {
-        String procName = labelValueToName.getOrDefault(frame.getLabelHash(), "");
+            Map<Integer, String> labelValueToName,
+            int labelNamespaceMask) {
+        String procName = labelValueToName.getOrDefault(
+                frame.getLabelHash() ^ labelNamespaceMask, "");
         int[] absReturnIp = vectorToArray(frame.getAbsoluteReturnIp());
         int[] absCallIp = frame.hasAbsoluteCallIp() ? vectorToArray(frame.getAbsoluteCallIp()) : null;
 

--- a/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
+++ b/src/main/java/org/evochora/datapipeline/resources/database/OrganismStateConverter.java
@@ -318,8 +318,7 @@ public final class OrganismStateConverter {
                     ? registerValuesBefore.get(registerId)
                     : null;
 
-                int index = locBank != null ? registerId - locBank.base : registerId;
-                resolvedArgs.add(InstructionArgumentView.register(index, registerValue, registerType));
+                resolvedArgs.add(InstructionArgumentView.register(registerId, registerValue, registerType));
                 argIndex++;
             } else if (argType == org.evochora.runtime.isa.InstructionArgumentType.LITERAL) {
                 // LITERAL: Decode molecule type and value (shown as IMMEDIATE in view)

--- a/src/main/java/org/evochora/datapipeline/utils/LabelNamespaceMask.java
+++ b/src/main/java/org/evochora/datapipeline/utils/LabelNamespaceMask.java
@@ -1,0 +1,106 @@
+package org.evochora.datapipeline.utils;
+
+import org.evochora.datapipeline.api.contracts.StoredMutationEvent;
+import org.evochora.datapipeline.api.contracts.StoredMutationEvents;
+import org.evochora.runtime.Config;
+import org.evochora.runtime.worldgen.LabelRewritePlugin;
+
+/**
+ * The label namespace a body's LABEL and LABELREF molecules stand in, read from the births of its
+ * ancestry.
+ * <p>
+ * Every newborn's labels and label references are XOR-masked once at birth
+ * ({@link LabelRewritePlugin}), and every descendant's again at its own birth. A label value in a
+ * body therefore equals the value the compiler gave it only for a founding organism; in every
+ * later body it carries the masks of all births in between. XOR composes those masks exactly:
+ * they are their own inverse and they commute, so one composed mask turns a value of one namespace
+ * into the other and back.
+ * <p>
+ * Two compositions are needed, because two questions are asked of the same births. A body's own
+ * values stand in the namespace of every mask its ancestry ever applied, which
+ * {@link #ofChain(Iterable)} composes. A value a plugin <em>recorded</em> at a birth stands in the
+ * namespace of that moment, and only the masks applied after it still have to be added, which
+ * {@link #recordedAfter(StoredMutationEvents, int)} composes: a mask with a smaller event index ran
+ * before the recording plugin, so the recorded value already carries it.
+ * <p>
+ * Label rewriting is core behaviour that happens to be implemented through the birth handler
+ * interface. That is why this one kind of event is interpreted here while every other kind is
+ * carried through as the plugin reported it.
+ * <p>
+ * <strong>Thread Safety:</strong> Stateless; all methods are static and operate only on their
+ * arguments.
+ */
+public final class LabelNamespaceMask {
+
+    private LabelNamespaceMask() {
+        // Utility class
+    }
+
+    /**
+     * Composes the mask that turns a compiled label value into the value it has in the body of an
+     * organism whose ancestry is given.
+     *
+     * @param chain The births of an ancestry, each with the events it recorded, in any order —
+     *              XOR does not depend on it
+     * @return The composed mask, zero for an ancestry that never rewrote a label
+     * @throws IllegalStateException if a label mask event carries no mask
+     */
+    public static int ofChain(Iterable<StoredMutationEvents> chain) {
+        int composed = 0;
+        for (final StoredMutationEvents events : chain) {
+            composed ^= ofBirth(events);
+        }
+        return composed;
+    }
+
+    /**
+     * Composes every label mask of one birth.
+     *
+     * @param events The events of that birth
+     * @return The composed mask, zero when the birth rewrote no label
+     * @throws IllegalStateException if a label mask event carries no mask
+     */
+    public static int ofBirth(StoredMutationEvents events) {
+        int composed = 0;
+        for (final StoredMutationEvent event : events.getEventsList()) {
+            composed ^= of(event);
+        }
+        return composed;
+    }
+
+    /**
+     * Composes the label masks of one birth that were applied after a given event of that birth.
+     *
+     * @param events The events of that birth
+     * @param index Ordinal of the event the masks are composed for
+     * @return The composed mask, zero when no later event of that birth is a label mask
+     * @throws IllegalStateException if a label mask event carries no mask
+     */
+    public static int recordedAfter(StoredMutationEvents events, int index) {
+        int composed = 0;
+        for (int i = index + 1; i < events.getEventsCount(); i++) {
+            composed ^= of(events.getEvents(i));
+        }
+        return composed;
+    }
+
+    /**
+     * Reads the mask one event carries.
+     *
+     * @param event The event to read
+     * @return The mask, narrowed to the bits a label value may use, or zero if the event is not a
+     *         label mask
+     * @throws IllegalStateException if a label mask event carries no mask
+     */
+    private static int of(StoredMutationEvent event) {
+        if (!LabelRewritePlugin.MUTATION_KIND.equals(event.getKind())) {
+            return 0;
+        }
+        if (event.getParamsCount() == 0) {
+            throw new IllegalStateException("An event of kind '" + LabelRewritePlugin.MUTATION_KIND
+                + "' reported by " + event.getPluginClass() + " carries no mask, so no label value"
+                + " of its lineage can be placed in a later namespace");
+        }
+        return (int) (event.getParams(0) & Config.LABEL_VALUE_MASK);
+    }
+}

--- a/src/main/java/org/evochora/node/processes/http/api/visualizer/LineageMutationTranslator.java
+++ b/src/main/java/org/evochora/node/processes/http/api/visualizer/LineageMutationTranslator.java
@@ -7,13 +7,13 @@ import java.util.List;
 import org.evochora.datapipeline.api.contracts.StoredMutationEvent;
 import org.evochora.datapipeline.api.contracts.StoredMutationEvents;
 import org.evochora.datapipeline.api.resources.database.dto.LineageMutations;
+import org.evochora.datapipeline.utils.LabelNamespaceMask;
 import org.evochora.node.processes.http.api.visualizer.dto.OrganismMutationsResponseDto.MoleculeView;
 import org.evochora.node.processes.http.api.visualizer.dto.OrganismMutationsResponseDto.MutationCellView;
 import org.evochora.node.processes.http.api.visualizer.dto.OrganismMutationsResponseDto.MutationEventView;
 import org.evochora.runtime.Config;
 import org.evochora.runtime.model.EnvironmentProperties;
 import org.evochora.runtime.model.Molecule;
-import org.evochora.runtime.worldgen.LabelRewritePlugin;
 
 /**
  * Turns the stored mutations of an ancestry chain into the events of one displayed body.
@@ -23,25 +23,16 @@ import org.evochora.runtime.worldgen.LabelRewritePlugin;
  * received it, so the displayed organism's own initial position turns them into world
  * coordinates. The second is the label namespace.
  * <p>
- * <strong>Why label values are translated.</strong> Every newborn's LABEL and LABELREF molecules
- * are XOR-masked once at birth, after the mutation plugins have run
- * ({@link LabelRewritePlugin}), and every descendant's again at its own birth. The value a
- * mutation plugin recorded for such a cell therefore equals the value in no later body: between
- * the record and the body stand one mask per birth. Composing those masks is what makes the two
- * comparable, and XOR composes them exactly — the masks are their own inverse and commute, so the
- * value as it stands in the displayed body is the recorded value XORed with the masks of every
- * birth from the recording organism down to the displayed one. Within the recording birth itself
- * only the masks recorded after the mutation apply: a mask with a smaller event index ran before
- * the mutation plugin, and the value the plugin then wrote already carries it.
+ * <strong>Why label values are translated.</strong> The value a mutation plugin recorded for a
+ * LABEL or LABELREF cell equals the value in no later body: between the record and the body stand
+ * the label masks of one birth after another. {@link LabelNamespaceMask} composes them, and
+ * {@link LabelNamespaceMask#recordedAfter} is the composition a record needs — the masks of the
+ * recording birth that were applied after the plugin wrote.
  * <p>
  * A mask touches only the value bits of a molecule — it is drawn from
  * {@link Config#LABEL_VALUE_MASK}, which is narrower than the value field — so it is applied to
  * the packed molecule directly. Molecules of any other type pass through untouched: they were
  * never masked.
- * <p>
- * Label rewriting is core behaviour that happens to be implemented through the birth handler
- * interface, which is why this one kind of event is known here while every other kind is carried
- * through as the plugin reported it.
  * <p>
  * <strong>Thread Safety:</strong> Stateless; all methods are static and operate only on their
  * arguments.
@@ -80,9 +71,10 @@ final class LineageMutationTranslator {
         for (final LineageMutations entry : chain) {
             final StoredMutationEvents events = entry.events();
             for (int index = 0; index < events.getEventsCount(); index++) {
-                views.add(view(entry, index, descendantMasks ^ laterMasks(events, index), anchor, world));
+                views.add(view(entry, index,
+                    descendantMasks ^ LabelNamespaceMask.recordedAfter(events, index), anchor, world));
             }
-            descendantMasks ^= allMasks(events);
+            descendantMasks ^= LabelNamespaceMask.ofBirth(events);
         }
 
         views.sort(Comparator.comparingInt(MutationEventView::originGeneration)
@@ -150,54 +142,6 @@ final class LineageMutationTranslator {
             dv,
             params,
             cells);
-    }
-
-    /**
-     * Composes the label masks of one birth that were recorded after a given event.
-     *
-     * @param events The events of that birth
-     * @param index Ordinal of the event the masks are composed for
-     * @return The composed mask, zero when no later event of that birth is a label mask
-     */
-    private static int laterMasks(final StoredMutationEvents events, final int index) {
-        int composed = 0;
-        for (int i = index + 1; i < events.getEventsCount(); i++) {
-            composed ^= maskOf(events.getEvents(i));
-        }
-        return composed;
-    }
-
-    /**
-     * Composes every label mask of one birth.
-     *
-     * @param events The events of that birth
-     * @return The composed mask, zero when the birth recorded no label mask
-     */
-    private static int allMasks(final StoredMutationEvents events) {
-        int composed = 0;
-        for (final StoredMutationEvent event : events.getEventsList()) {
-            composed ^= maskOf(event);
-        }
-        return composed;
-    }
-
-    /**
-     * Reads the mask an event carries, or zero if it is not a label mask.
-     *
-     * @param event The event to read
-     * @return The mask, narrowed to the bits a label value may use
-     * @throws IllegalStateException if a label mask event carries no mask
-     */
-    private static int maskOf(final StoredMutationEvent event) {
-        if (!LabelRewritePlugin.MUTATION_KIND.equals(event.getKind())) {
-            return 0;
-        }
-        if (event.getParamsCount() == 0) {
-            throw new IllegalStateException("An event of kind '" + LabelRewritePlugin.MUTATION_KIND
-                + "' reported by " + event.getPluginClass() + " carries no mask, so no label value"
-                + " of its lineage can be placed in a later namespace");
-        }
-        return (int) (event.getParams(0) & Config.LABEL_VALUE_MASK);
     }
 
     /**

--- a/src/main/resources/web/visualizer/js/AppController.js
+++ b/src/main/resources/web/visualizer/js/AppController.js
@@ -2,7 +2,7 @@ import { EnvironmentApi, setTypeMappings } from './api/EnvironmentApi.js';
 import { OrganismApi } from './api/OrganismApi.js';
 import { SimulationApi } from './api/SimulationApi.js';
 import { EnvironmentGrid } from './EnvironmentGrid.js';
-import { buildMarkMap, genomeEdges } from './MutationMarks.js';
+import { buildMarkMap } from './MutationMarks.js';
 import { moleculeTypeName } from './MoleculeTypePalette.js';
 import { MinimapView } from './ui/minimap/MinimapView.js';
 import { OrganismInstructionView } from './ui/organism/OrganismInstructionView.js';
@@ -64,10 +64,8 @@ export class AppController {
         this._genomeParent = new Map();       // String(genomeHash) → String(parentGenomeHash) | null
         this._genomeColorCache = new Map();   // String(genomeHash) → int 0xRRGGBB
         this._genomeHslCache = new Map();     // String(genomeHash) → [h, s, l]
-        // Mutations of the selected organism's lineage: the organism they were fetched for, and the
-        // genome→parentGenome edges of the answer, which the tick's own closure does not carry
+        // The organism the mutations of the selected lineage were fetched for
         this._mutationsOrganismId = null;     // int | null
-        this._mutationGenomeEdges = null;     // [[String(genomeHash), String(parentGenomeHash) | null], ...]
         
         // Config for renderer
         const defaultConfig = {
@@ -898,10 +896,6 @@ export class AppController {
             const organisms = organismResult.organisms;
             this.state.totalOrganismCount = organismResult.totalOrganismCount;
             this._applyGenomeAncestors(organismResult.genomeAncestors);
-            // The genomes of the selected lineage's mutations are not part of the tick's closure,
-            // and every colour of this tick is computed from here on, so their edges go back in
-            // before the first of them is drawn.
-            this._mergeLineageGenomeEdges();
             this.updateOrganismPanel(organisms, isForwardStep);
             this.minimapView?.setOwnershipColorResolver(this._minimapOwnershipColorResolver(organisms));
             this.minimapView?.updateOrganisms(
@@ -1103,8 +1097,6 @@ export class AppController {
             }
 
             const events = answer?.events || [];
-            this._mutationGenomeEdges = genomeEdges(events);
-            this._mergeLineageGenomeEdges();
             this.renderer?.setMutationMarks(
                 buildMarkMap(events, {
                     resolveTypeName: (moleculeType) => this._resolveMoleculeTypeName(moleculeType)
@@ -1134,32 +1126,7 @@ export class AppController {
             this.organismMutationsRequestController = null;
         }
         this._mutationsOrganismId = null;
-        this._mutationGenomeEdges = null;
         this.renderer?.setMutationMarks(null);
-    }
-
-    /**
-     * Adds the ancestry edges of the selected lineage's mutations to the genome ancestor map.
-     *
-     * A mutation is coloured by the genome it arose in, and that genome is often carried by no
-     * organism any more. Without its parent it would be coloured as a root of its own instead of as
-     * part of the lineage it belongs to, so its edge is added whenever the map has been replaced.
-     * @private
-     */
-    _mergeLineageGenomeEdges() {
-        if (!this._mutationGenomeEdges) {
-            return;
-        }
-        let added = false;
-        for (const [genomeHash, parentGenomeHash] of this._mutationGenomeEdges) {
-            if (this._genomeParent.get(genomeHash) === parentGenomeHash) continue;
-            this._genomeParent.set(genomeHash, parentGenomeHash);
-            added = true;
-        }
-        if (added) {
-            this._genomeColorCache.clear();
-            this._genomeHslCache.clear();
-        }
     }
 
     /**

--- a/src/main/resources/web/visualizer/js/AppController.js
+++ b/src/main/resources/web/visualizer/js/AppController.js
@@ -301,6 +301,7 @@ export class AppController {
         this.sourceView.setProgram(null);
         this.stateView.setProgram(null);
         this.instructionView.setProgram(null);
+        this.instructionView.setLabelNamespaceMask(0);
         this.state.previousOrganismDetails = null;
     }
     
@@ -457,6 +458,7 @@ export class AppController {
                     : null;
                 this.stateView.setProgram(artifact);
                 this.instructionView.setProgram(artifact);
+                this.instructionView.setLabelNamespaceMask(staticInfo.labelNamespaceMask);
                 this.sourceView.setProgram(artifact);
 
                 // Update instruction view with last and next instructions

--- a/src/main/resources/web/visualizer/js/MutationMarks.js
+++ b/src/main/resources/web/visualizer/js/MutationMarks.js
@@ -97,32 +97,6 @@ export function isMarkPresent(mark, typeName, value, isEmptyCell) {
 }
 
 /**
- * Collects the genome to parent genome edges the answer carries.
- *
- * Every event names the genome the mutation arose in and that genome's parent. An ancestor genome
- * that no living organism carries appears in no other answer of the view, so without these edges it
- * would be coloured as a root of its own instead of as part of its lineage.
- *
- * @param {Array<object>} events The events of the lineage.
- * @returns {Array<Array<string|null>>} Pairs of genome hash and parent genome hash, the parent null
- *                                      for a genome whose organism had no parent.
- */
-export function genomeEdges(events) {
-    const edges = new Map();
-    if (!Array.isArray(events)) {
-        return [];
-    }
-    for (const event of events) {
-        if (event.originGenomeHash == null) {
-            continue;
-        }
-        edges.set(String(event.originGenomeHash),
-            event.originParentGenomeHash != null ? String(event.originParentGenomeHash) : null);
-    }
-    return [...edges.entries()];
-}
-
-/**
  * Builds one mark from one cell of one event.
  *
  * @param {object} event The event the cell belongs to.

--- a/src/main/resources/web/visualizer/js/annotator/SourceAnnotator.js
+++ b/src/main/resources/web/visualizer/js/annotator/SourceAnnotator.js
@@ -36,9 +36,11 @@ export class SourceAnnotator {
      * @param {string} fileName The name of the source file being annotated.
      * @param {string} sourceLine The raw text of the source code line.
      * @param {number} lineNumber The 1-based line number.
+     * @param {number} labelNamespaceMask The organism's label namespace, which turns a compiled
+     *        label value into the value that stands in its body.
      * @returns {Array<object>} A list of annotation spans ready for rendering.
      */
-    annotate(organismState, artifact, fileName, sourceLine, lineNumber) {
+    annotate(organismState, artifact, fileName, sourceLine, lineNumber, labelNamespaceMask) {
         if (!artifact || !organismState || !fileName) return [];
 
         const tokenLookup = artifact.tokenLookup;
@@ -108,7 +110,7 @@ export class SourceAnnotator {
                         const handler = this.findHandler(tokenText, tokenInfo);
                         if (handler) {
                             try {
-                            const result = handler.analyze(tokenText, tokenInfo, organismState, artifact);
+                            const result = handler.analyze(tokenText, tokenInfo, organismState, artifact, labelNamespaceMask);
                             if (result) {
                                 annotations.push({
                                     tokenText: tokenText,

--- a/src/main/resources/web/visualizer/js/annotator/handlers/LabelReferenceTokenHandler.js
+++ b/src/main/resources/web/visualizer/js/annotator/handlers/LabelReferenceTokenHandler.js
@@ -27,10 +27,12 @@ export class LabelReferenceTokenHandler {
      * @param {object} tokenInfo Metadata about the token.
      * @param {object} organismState The current state of the organism (not used for hash lookup).
      * @param {object} artifact The program artifact containing `labelNameToValue` map.
+     * @param {number} labelNamespaceMask The organism's label namespace; the compiled value
+     *        XORed with it is the value that stands in this organism's body.
      * @returns {object} An annotation object `{ annotationText, kind }`.
      * @throws {Error} If the label hash cannot be resolved.
      */
-    analyze(tokenText, tokenInfo, organismState, artifact) {
+    analyze(tokenText, tokenInfo, organismState, artifact, labelNamespaceMask) {
         // Resolve label name to hash value for display (using qualified name for lookup)
         const hashValue = AnnotationUtils.resolveLabelNameToHash(tokenText, artifact, tokenInfo.qualifiedName);
 
@@ -44,7 +46,7 @@ export class LabelReferenceTokenHandler {
 
         // Format hash value as decimal with # prefix (e.g., "[#12345]")
         return {
-            annotationText: `[#${hashValue}]`,
+            annotationText: `[#${hashValue ^ labelNamespaceMask}]`,
             kind: 'label-ref'
         };
     }

--- a/src/main/resources/web/visualizer/js/annotator/handlers/ProcedureTokenHandler.js
+++ b/src/main/resources/web/visualizer/js/annotator/handlers/ProcedureTokenHandler.js
@@ -27,10 +27,12 @@ export class ProcedureTokenHandler {
      * @param {object} tokenInfo Metadata about the token.
      * @param {object} organismState The current state of the organism (not used for hash lookup).
      * @param {object} artifact The program artifact containing `labelNameToValue` map.
+     * @param {number} labelNamespaceMask The organism's label namespace; the compiled value
+     *        XORed with it is the value that stands in this organism's body.
      * @returns {object} An annotation object `{ annotationText, kind }`.
      * @throws {Error} If the procedure hash cannot be resolved.
      */
-    analyze(tokenText, tokenInfo, organismState, artifact) {
+    analyze(tokenText, tokenInfo, organismState, artifact, labelNamespaceMask) {
         // Resolve procedure name to hash value for display (using qualified name for lookup)
         const hashValue = AnnotationUtils.resolveLabelNameToHash(tokenText, artifact, tokenInfo.qualifiedName);
 
@@ -44,7 +46,7 @@ export class ProcedureTokenHandler {
 
         // Format hash value as decimal with # prefix (e.g., "[#12345]")
         return {
-            annotationText: `[#${hashValue}]`,
+            annotationText: `[#${hashValue ^ labelNamespaceMask}]`,
             kind: 'proc'
         };
     }

--- a/src/main/resources/web/visualizer/js/ui/organism/OrganismInstructionView.js
+++ b/src/main/resources/web/visualizer/js/ui/organism/OrganismInstructionView.js
@@ -17,6 +17,7 @@ export class OrganismInstructionView {
     constructor(root) {
         this.root = root;
         this.artifact = null;
+        this.labelNamespaceMask = 0;
     }
 
     /**
@@ -26,6 +27,16 @@ export class OrganismInstructionView {
      */
     setProgram(artifact) {
         this.artifact = artifact;
+    }
+
+    /**
+     * Sets the label namespace of the organism whose instructions are shown.
+     * A label value in its body is the compiled value XORed with this mask, so the mask turns the
+     * value an operand carries back into the one the artifact knows a name for.
+     * @param {number} labelNamespaceMask - The organism's mask, 0 if its ancestry rewrote no label.
+     */
+    setLabelNamespaceMask(labelNamespaceMask) {
+        this.labelNamespaceMask = labelNamespaceMask;
     }
     
     /**
@@ -202,8 +213,13 @@ export class OrganismInstructionView {
                     const molecule = { kind: 'MOLECULE', type: arg.moleculeType, value: arg.value };
                     formatted = ValueFormatter.format(molecule);
                 }
-                // Annotate with label name if artifact is available
-                const labelName = AnnotationUtils.resolveLabelHashToName(arg.value, this.artifact);
+                // Annotate with label name if artifact is available. The mask is applied only to a
+                // value that is there: XOR would turn a missing one into the mask itself, which
+                // resolves to whatever label sits at that value rather than to nothing.
+                const labelName = (arg.value === null || arg.value === undefined)
+                    ? null
+                    : AnnotationUtils.resolveLabelHashToName(
+                        arg.value ^ this.labelNamespaceMask, this.artifact);
                 if (labelName) {
                     return `${formatted}<span class="annotation">=${labelName}</span>`;
                 }

--- a/src/main/resources/web/visualizer/js/ui/organism/OrganismSourceView.js
+++ b/src/main/resources/web/visualizer/js/ui/organism/OrganismSourceView.js
@@ -72,11 +72,11 @@ export class OrganismSourceView {
         if (!this.artifact || !this.dom.section) return;
 
         const activeLocation = this.calculateActiveLocation(organismState, staticInfo);
-        
-        // 1. Handle Status Bar (Errors/Warnings including mutation detection)
-        this.updateStatusBar(activeLocation, organismState);
 
-        // 2. Auto-switch file if execution moved to a different file
+        // 1. Auto-switch file if execution moved to a different file. This comes first because the
+        // re-render replaces the whole source view, the status bar with it: a warning written
+        // before it would be thrown away again, which is why one only ever appeared when execution
+        // happened to stay in the file already on display.
         if (activeLocation && activeLocation.fileName) {
             const fileExists = this.artifact.sources && this.artifact.sources[activeLocation.fileName];
             if (fileExists && this.selectedFile !== activeLocation.fileName) {
@@ -85,6 +85,9 @@ export class OrganismSourceView {
                 this.renderSourceStructure(); // Re-render needed because file content changed
             }
         }
+
+        // 2. Handle Status Bar (Errors/Warnings including mutation detection)
+        this.updateStatusBar(activeLocation, organismState);
 
         // 3. Update Line Highlighting (DOM manipulation only, no re-render)
         const activeLineNumber = activeLocation ? activeLocation.lineNumber : null;

--- a/src/main/resources/web/visualizer/js/ui/organism/OrganismSourceView.js
+++ b/src/main/resources/web/visualizer/js/ui/organism/OrganismSourceView.js
@@ -367,7 +367,8 @@ export class OrganismSourceView {
             initialPosition: staticInfo.initialPosition ? { components: staticInfo.initialPosition } : undefined
         };
 
-        const annotations = this.annotator.annotate(fullState, this.artifact, fileName, originalLine, lineNumber);
+        const annotations = this.annotator.annotate(fullState, this.artifact, fileName, originalLine,
+            lineNumber, staticInfo.labelNamespaceMask);
         if (!annotations || annotations.length === 0) {
             // Ensure clean state just in case
             lineElement.textContent = originalLine;
@@ -480,7 +481,7 @@ export class OrganismSourceView {
     updateStatusBar(activeLocation, organismState) {
         if (!this.dom.status) return;
 
-        // Collect warning message (location error, opcode mismatch, or unknown procedure)
+        // Collect warning message (location error or opcode mismatch)
         let warning = null;
 
         if (activeLocation && activeLocation.error) {
@@ -489,13 +490,6 @@ export class OrganismSourceView {
             const mismatch = this.detectOpcodeMismatch(activeLocation, organismState);
             if (mismatch) {
                 warning = `Opcode mismatch: expected ${mismatch.expected}, found ${mismatch.actual}`;
-            }
-        }
-
-        if (!warning) {
-            const unknownProc = this.detectUnknownProcedure(organismState);
-            if (unknownProc) {
-                warning = unknownProc;
             }
         }
 
@@ -541,34 +535,6 @@ export class OrganismSourceView {
             return { expected: expectedInstruction.opcode, actual: actualOpcode };
         }
         return null;
-    }
-
-    /**
-     * Detects if the organism is inside a procedure that is not in the compiled artifact.
-     *
-     * @param {object|null} organismState - The organism state with callStack.
-     * @returns {string|null} Warning message or null if all procedures are known.
-     * @private
-     */
-    detectUnknownProcedure(organismState) {
-        if (!organismState?.callStack || !Array.isArray(organismState.callStack) || organismState.callStack.length === 0) return null;
-        if (!this.artifact?.procNameToParamNames) return null;
-
-        const topFrame = organismState.callStack[0];
-        if (!topFrame) return null;
-
-        const procName = topFrame.procName || '';
-        const procNameUpper = procName.toUpperCase();
-
-        if (procNameUpper && this.artifact.procNameToParamNames[procNameUpper]) return null;
-
-        const callIp = topFrame.absoluteCallIp;
-        const posStr = (callIp && Array.isArray(callIp)) ? ` called at [${callIp.join('|')}]` : '';
-
-        if (procName) {
-            return `Unknown procedure: ${procName}${posStr}`;
-        }
-        return `Unknown procedure${posStr}`;
     }
 
     /**

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderInstructionResolutionTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderInstructionResolutionTest.java
@@ -168,7 +168,10 @@ class H2DatabaseReaderInstructionResolutionTest {
             assertThat(details.state.instructions.last.opcodeName).isEqualTo("DPLR");
             assertThat(details.state.instructions.last.arguments).hasSize(1);
             assertThat(details.state.instructions.last.arguments.get(0).type).isEqualTo("REGISTER");
-            assertThat(details.state.instructions.last.arguments.get(0).registerId).isEqualTo(0);
+            // The id names the register in the whole register space, as it does for a data register,
+            // so that a reader derives the index within the bank the same way for both
+            assertThat(details.state.instructions.last.arguments.get(0).registerId)
+                    .isEqualTo(org.evochora.runtime.isa.RegisterBank.LR.base);
             assertThat(details.state.instructions.last.arguments.get(0).registerType).isEqualTo("LR");
             assertThat(details.state.instructions.last.arguments.get(0).registerValue).isNotNull();
             assertThat(details.state.instructions.last.arguments.get(0).registerValue.kind).isEqualTo(org.evochora.datapipeline.api.resources.database.dto.RegisterValueView.Kind.VECTOR);

--- a/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderProcedureNameResolutionTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/H2DatabaseReaderProcedureNameResolutionTest.java
@@ -11,12 +11,15 @@ import org.evochora.datapipeline.api.contracts.OrganismState;
 import org.evochora.datapipeline.api.contracts.ProcFrame;
 import org.evochora.datapipeline.api.contracts.ProgramArtifact;
 import org.evochora.datapipeline.api.contracts.SimulationMetadata;
+import org.evochora.datapipeline.api.contracts.StoredMutationEvent;
+import org.evochora.datapipeline.api.contracts.StoredMutationEvents;
 import org.evochora.datapipeline.api.contracts.TickData;
 import org.evochora.datapipeline.api.contracts.Vector;
 import org.evochora.datapipeline.api.resources.database.IDatabaseReader;
 import org.evochora.datapipeline.api.resources.database.IDatabaseReaderProvider;
 import org.evochora.datapipeline.api.resources.database.dto.OrganismTickDetails;
 import org.evochora.junit.extensions.logging.LogWatchExtension;
+import org.evochora.runtime.worldgen.LabelRewritePlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -30,8 +33,10 @@ import com.typesafe.config.ConfigFactory;
  * Tests procedure name resolution in H2DatabaseReader.
  * <p>
  * Call frames persist a label hash, not a name. The name is recovered on read from the label map of
- * the program the organism descends from. These tests cover the three cases that arise: a hash the
- * map knows, a hash it does not, and a run whose metadata carries no map at all.
+ * the program the organism descends from, after the organism's own label namespace has been taken
+ * out of the hash. These tests cover the cases that arise: a hash the map knows, a hash it does
+ * not, a run whose metadata carries no map at all, and a descendant whose ancestry rewrote the
+ * labels it calls through.
  */
 @Tag("integration")
 @ExtendWith(LogWatchExtension.class)
@@ -44,6 +49,11 @@ class H2DatabaseReaderProcedureNameResolutionTest {
     private static final int KNOWN_HASH = 4711;
     private static final String KNOWN_NAME = "MAIN_LOOP";
     private static final int UNKNOWN_HASH = 9999;
+
+    private static final int CHILD_ID = 2;
+    private static final int GRANDCHILD_ID = 3;
+    private static final int CHILD_MASK = 0b101_0110_1010_1100_110;
+    private static final int GRANDCHILD_MASK = 0b011_1001_0011_0101_001;
 
     @TempDir
     Path tempChunkDir;
@@ -120,6 +130,31 @@ class H2DatabaseReaderProcedureNameResolutionTest {
         }
     }
 
+    /**
+     * Every newborn's labels and label references are XOR-masked into a namespace of its own, and
+     * every descendant's again at its own birth. A frame of the third generation therefore holds a
+     * hash that is the compiled value XORed with both masks, and only their composition recovers
+     * the name the artifact knows. A chain of two would still pass if only the organism's own mask
+     * were applied, which is the mistake worth catching.
+     */
+    @Test
+    void resolvesNameThroughTheLabelMasksOfAWholeAncestry() throws Exception {
+        setupDatabase(true);
+        writeAncestryWithMaskedCallStack(KNOWN_HASH ^ CHILD_MASK ^ GRANDCHILD_MASK);
+
+        try (IDatabaseReader reader = provider.createReader(runId)) {
+            OrganismTickDetails grandchild = reader.readOrganismDetails(TICK, GRANDCHILD_ID);
+            assertThat(grandchild.staticInfo.labelNamespaceMask).isEqualTo(CHILD_MASK ^ GRANDCHILD_MASK);
+            assertThat(grandchild.state.callStack).hasSize(1);
+            assertThat(grandchild.state.callStack.get(0).procName).isEqualTo(KNOWN_NAME);
+
+            // The founding organism of the same chain rewrote nothing and must stay untouched
+            OrganismTickDetails founder = reader.readOrganismDetails(TICK, ORGANISM_ID);
+            assertThat(founder.staticInfo.labelNamespaceMask).isZero();
+            assertThat(founder.state.callStack.get(0).procName).isEqualTo(KNOWN_NAME);
+        }
+    }
+
     private void setupDatabase(boolean withLabelMap) throws Exception {
         Object connObj = database.acquireDedicatedConnection();
         try (Connection conn = (Connection) connObj) {
@@ -188,5 +223,82 @@ class H2DatabaseReaderProcedureNameResolutionTest {
             database.doWriteOrganismTick(conn, tick, java.util.Map.of());
             database.doCommitOrganismWrites(conn);
         }
+    }
+
+    /**
+     * Writes a founding organism, its child and its grandchild into one tick, each newborn with the
+     * label mask its birth applied. The founder and the grandchild both carry a call stack, so that
+     * one read covers the masked case and the unmasked one.
+     *
+     * @param grandchildLabelHash the hash the grandchild's frame carries
+     */
+    private void writeAncestryWithMaskedCallStack(int grandchildLabelHash) throws Exception {
+        Object connObj = database.acquireDedicatedConnection();
+        try (Connection conn = (Connection) connObj) {
+            org.evochora.datapipeline.utils.H2SchemaUtil.setSchema(conn, runId);
+
+            TickData tick = TickData.newBuilder()
+                    .setTickNumber(TICK)
+                    .setSimulationRunId(runId)
+                    .addOrganisms(organism(ORGANISM_ID, null, KNOWN_HASH))
+                    .addOrganisms(organism(CHILD_ID, ORGANISM_ID, null))
+                    .addOrganisms(organism(GRANDCHILD_ID, CHILD_ID, grandchildLabelHash))
+                    .build();
+
+            database.doWriteOrganismTick(conn, tick, java.util.Map.of(
+                    CHILD_ID, labelRewrite(CHILD_MASK),
+                    GRANDCHILD_ID, labelRewrite(GRANDCHILD_MASK)));
+            database.doCommitOrganismWrites(conn);
+        }
+    }
+
+    /**
+     * Builds one organism of the ancestry.
+     *
+     * @param organismId the organism's id
+     * @param parentId   its parent's id, or {@code null} for the founding organism
+     * @param labelHash  the hash of its single call frame, or {@code null} for an empty call stack
+     * @return the organism state as a tick carries it
+     */
+    private OrganismState organism(int organismId, Integer parentId, Integer labelHash) {
+        OrganismState.Builder builder = OrganismState.newBuilder()
+                .setOrganismId(organismId)
+                .setBirthTick(0)
+                .setProgramId(PROGRAM_ID)
+                .setInitialPosition(Vector.newBuilder().addComponents(0).addComponents(0).build())
+                .setEnergy(100)
+                .setIp(Vector.newBuilder().addComponents(1).addComponents(2).build())
+                .setDv(Vector.newBuilder().addComponents(0).addComponents(1).build())
+                .addDataPointers(Vector.newBuilder().addComponents(5).addComponents(5).build())
+                .setActiveDpIndex(0);
+        if (parentId != null) {
+            builder.setParentId(parentId);
+        }
+        if (labelHash != null) {
+            builder.addCallStack(ProcFrame.newBuilder()
+                    .setLabelHash(labelHash)
+                    .setAbsoluteReturnIp(Vector.newBuilder().addComponents(3).addComponents(4).build())
+                    .build());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Serializes the birth events of an organism whose labels were rewritten with one mask.
+     *
+     * @param mask the mask that birth applied
+     * @return the stored events as the organisms table holds them
+     */
+    private byte[] labelRewrite(int mask) {
+        return StoredMutationEvents.newBuilder()
+                .addEvents(StoredMutationEvent.newBuilder()
+                        .setPluginClass(LabelRewritePlugin.class.getName())
+                        .setKind(LabelRewritePlugin.MUTATION_KIND)
+                        .addParams(mask)
+                        .addDv(1)
+                        .addDv(0)
+                        .build())
+                .build()
+                .toByteArray();
     }
 }

--- a/src/test/java/org/evochora/datapipeline/resources/database/OrganismStateConverterArgumentCellsTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/OrganismStateConverterArgumentCellsTest.java
@@ -26,11 +26,13 @@ import org.junit.jupiter.api.Test;
 class OrganismStateConverterArgumentCellsTest {
 
     private static int setiId;
+    private static int jmpiId;
 
     @BeforeAll
     static void registerInstructionSet() {
         Instruction.init();
         setiId = Instruction.getInstructionIdByName("SETI");
+        jmpiId = Instruction.getInstructionIdByName("JMPI");
     }
 
     /** SETI takes a register and a literal, so a complete record holds two cells. */
@@ -64,6 +66,25 @@ class OrganismStateConverterArgumentCellsTest {
         assertThat(view.arguments).hasSize(2);
         assertThat(view.arguments.get(1).moleculeType).isEqualTo("ENERGY");
         assertThat(view.arguments.get(1).value).isEqualTo(42);
+    }
+
+    /**
+     * A label operand is one cell holding the hash of the label the jump was compiled against.
+     * It reaches the view as its own kind, with the molecule type it is stored as, so that a cell
+     * carrying something else than the compiler wrote there is visible as such.
+     */
+    @Test
+    void resolvesTheLabelOperandOfAJump() {
+        InstructionView view = OrganismStateConverter.resolveInstructionView(
+                jmpiId, List.of(new Molecule(Config.TYPE_DATA, 4711).toInt()),
+                0, 0, new int[]{1, 2}, new int[]{1, 0},
+                false, null, List.of(), new int[]{100, 100}, null);
+
+        assertThat(view.opcodeName).isEqualTo("JMPI");
+        assertThat(view.argumentTypes).containsExactly("LABEL");
+        assertThat(view.arguments).hasSize(1);
+        assertThat(view.arguments.get(0).moleculeType).isEqualTo("DATA");
+        assertThat(view.arguments.get(0).value).isEqualTo(4711);
     }
 
     /** A record that ends before the signature does is a defect and says so. */

--- a/src/test/java/org/evochora/datapipeline/resources/database/OrganismStateConverterArgumentCellsTest.java
+++ b/src/test/java/org/evochora/datapipeline/resources/database/OrganismStateConverterArgumentCellsTest.java
@@ -1,0 +1,77 @@
+package org.evochora.datapipeline.resources.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.evochora.datapipeline.api.resources.database.dto.InstructionView;
+import org.evochora.runtime.Config;
+import org.evochora.runtime.isa.Instruction;
+import org.evochora.runtime.model.Molecule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests how an instruction's recorded argument cells are turned into operands.
+ * <p>
+ * The cells of an instruction are read by a length and described by a signature, and both are
+ * derived from one list of operand sources when the instruction is registered. A record with
+ * fewer cells than the signature describes can therefore not come from an organism whose code was
+ * overwritten — such cells are recorded with other contents, not with fewer entries. It would mean
+ * those two derivations disagree, and that is a defect rather than something to display.
+ */
+@Tag("unit")
+class OrganismStateConverterArgumentCellsTest {
+
+    private static int setiId;
+
+    @BeforeAll
+    static void registerInstructionSet() {
+        Instruction.init();
+        setiId = Instruction.getInstructionIdByName("SETI");
+    }
+
+    /** SETI takes a register and a literal, so a complete record holds two cells. */
+    private static InstructionView resolve(List<Integer> cells) {
+        return OrganismStateConverter.resolveInstructionView(
+                setiId, cells, 0, 0, new int[]{1, 2}, new int[]{1, 0},
+                false, null, List.of(), new int[]{100, 100}, null);
+    }
+
+    @Test
+    void resolvesEveryOperandOfACompleteRecord() {
+        InstructionView view = resolve(List.of(
+                new Molecule(Config.TYPE_REGISTER, 0).toInt(),
+                new Molecule(Config.TYPE_DATA, 5).toInt()));
+
+        assertThat(view.opcodeName).isEqualTo("SETI");
+        assertThat(view.arguments).hasSize(2);
+        assertThat(view.argumentTypes).containsExactly("REGISTER", "IMMEDIATE");
+    }
+
+    /**
+     * An overwritten operand cell still is a cell: it arrives with whatever now stands in it, and
+     * is resolved like any other. Nothing here fails, because nothing here is broken.
+     */
+    @Test
+    void resolvesAnOperandCellThatHoldsSomethingElseNow() {
+        InstructionView view = resolve(List.of(
+                new Molecule(Config.TYPE_REGISTER, 0).toInt(),
+                new Molecule(Config.TYPE_ENERGY, 42).toInt()));
+
+        assertThat(view.arguments).hasSize(2);
+        assertThat(view.arguments.get(1).moleculeType).isEqualTo("ENERGY");
+        assertThat(view.arguments.get(1).value).isEqualTo(42);
+    }
+
+    /** A record that ends before the signature does is a defect and says so. */
+    @Test
+    void failsOnARecordShorterThanTheSignature() {
+        assertThatThrownBy(() -> resolve(List.of(new Molecule(Config.TYPE_REGISTER, 0).toInt())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SETI")
+                .hasMessageContaining("declares 2 operands");
+    }
+}

--- a/src/test/java/org/evochora/datapipeline/utils/LabelNamespaceMaskTest.java
+++ b/src/test/java/org/evochora/datapipeline/utils/LabelNamespaceMaskTest.java
@@ -1,0 +1,114 @@
+package org.evochora.datapipeline.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.evochora.datapipeline.api.contracts.StoredMutationEvent;
+import org.evochora.datapipeline.api.contracts.StoredMutationEvents;
+import org.evochora.junit.extensions.logging.LogWatchExtension;
+import org.evochora.runtime.Config;
+import org.evochora.runtime.worldgen.LabelRewritePlugin;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Unit tests for {@link LabelNamespaceMask}.
+ * <p>
+ * The subject is which births a mask is composed of. A body carries the masks of every birth of its
+ * ancestry, while a value recorded during a birth carries only those of that birth that ran after
+ * the recording, so the two compositions are checked against the same events.
+ */
+@Tag("unit")
+@ExtendWith(LogWatchExtension.class)
+class LabelNamespaceMaskTest {
+
+    private static StoredMutationEvent labelMask(long mask) {
+        return StoredMutationEvent.newBuilder()
+                .setPluginClass(LabelRewritePlugin.class.getName())
+                .setKind(LabelRewritePlugin.MUTATION_KIND)
+                .addParams(mask)
+                .build();
+    }
+
+    private static StoredMutationEvent otherKind() {
+        return StoredMutationEvent.newBuilder()
+                .setPluginClass("org.evochora.runtime.worldgen.GeneSubstitutionPlugin")
+                .setKind("substitution")
+                .addParams(0x7FFFFL)
+                .build();
+    }
+
+    private static StoredMutationEvents birth(StoredMutationEvent... events) {
+        return StoredMutationEvents.newBuilder().addAllEvents(List.of(events)).build();
+    }
+
+    @Test
+    void composesTheMasksOfEveryBirthOfAnAncestry() {
+        final int composed = LabelNamespaceMask.ofChain(List.of(
+                birth(labelMask(0x0000F)),
+                birth(labelMask(0x000F0)),
+                birth(labelMask(0x00F00))));
+
+        assertThat(composed).isEqualTo(0x00FFF);
+    }
+
+    @Test
+    void reportsNoMaskForAnAncestryThatRewroteNoLabel() {
+        assertThat(LabelNamespaceMask.ofChain(List.of(birth(otherKind()), birth()))).isZero();
+    }
+
+    @Test
+    void cancelsAMaskThatAnAncestryAppliedTwice() {
+        // XOR is its own inverse, which is what lets one composed mask carry a value both ways
+        final int composed = LabelNamespaceMask.ofChain(List.of(
+                birth(labelMask(0x2AAAA)),
+                birth(labelMask(0x2AAAA))));
+
+        assertThat(composed).isZero();
+    }
+
+    @Test
+    void composesEveryMaskOfOneBirthAndIgnoresOtherKinds() {
+        assertThat(LabelNamespaceMask.ofBirth(birth(labelMask(0x000F0), otherKind(), labelMask(0x0000F))))
+                .isEqualTo(0x000FF);
+    }
+
+    @Test
+    void narrowsAMaskToTheBitsALabelValueUses() {
+        // The plugin reports a full 64-bit parameter; a label value holds fewer bits than that
+        assertThat(LabelNamespaceMask.ofBirth(birth(labelMask(-1L))))
+                .isEqualTo(Config.LABEL_VALUE_MASK);
+    }
+
+    @Test
+    void composesOnlyTheMasksOfABirthThatRanAfterTheRecordedEvent() {
+        // The event the value was recorded at is a mask itself, so leaving it in would show
+        final StoredMutationEvents events =
+                birth(labelMask(0x0000F), labelMask(0x000F0), otherKind(), labelMask(0x00F00));
+
+        assertThat(LabelNamespaceMask.recordedAfter(events, 1)).isEqualTo(0x00F00);
+    }
+
+    @Test
+    void reportsNoMaskForTheLastEventOfABirth() {
+        final StoredMutationEvents events = birth(otherKind(), labelMask(0x0000F));
+
+        assertThat(LabelNamespaceMask.recordedAfter(events, events.getEventsCount() - 1)).isZero();
+    }
+
+    @Test
+    void refusesALabelMaskEventThatCarriesNoMask() {
+        final StoredMutationEvents events = birth(StoredMutationEvent.newBuilder()
+                .setPluginClass(LabelRewritePlugin.class.getName())
+                .setKind(LabelRewritePlugin.MUTATION_KIND)
+                .build());
+
+        assertThatThrownBy(() -> LabelNamespaceMask.ofBirth(events))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(LabelRewritePlugin.MUTATION_KIND)
+                .hasMessageContaining(LabelRewritePlugin.class.getName());
+    }
+}

--- a/src/test/java/org/evochora/node/NodeIntegrationTest.java
+++ b/src/test/java/org/evochora/node/NodeIntegrationTest.java
@@ -8,11 +8,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.net.ServerSocket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.evochora.junit.extensions.logging.AllowLog;
 import org.evochora.junit.extensions.logging.LogLevel;
 import org.evochora.junit.extensions.logging.LogWatchExtension;
@@ -162,11 +165,43 @@ class NodeIntegrationTest {
         // because which one it stopped at is the whole answer: RUNNING means the stop is still
         // under way, while ERROR means a service thread survived its interrupt and the status will
         // never become STOPPED, however long this waits.
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            final String status = given().get(BASE_PATH + "/status")
-                .then().extract().path("status");
-            assertThat("pipeline status after /stop", status, equalTo("STOPPED"));
-        });
+        try {
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                final String status = given().get(BASE_PATH + "/status")
+                    .then().extract().path("status");
+                assertThat("pipeline status after /stop", status, equalTo("STOPPED"));
+            });
+        } catch (final ConditionTimeoutException e) {
+            throw new AssertionError(e.getMessage() + System.lineSeparator() + threadDump(), e);
+        }
+    }
+
+    /**
+     * Every thread with its full stack and the monitor it holds or waits for.
+     *
+     * <p>The wait above can run out for two reasons that its own message cannot tell apart. Either
+     * the status kept coming back as something other than STOPPED, which the message then names,
+     * or a status request never returned at all, in which case the assertion is never reached and
+     * the message carries no status. Only the stacks say which thread is stuck and on what.
+     *
+     * @return a printable dump of all live threads.
+     */
+    private static String threadDump() {
+        final StringBuilder dump = new StringBuilder("Thread dump:");
+        for (final ThreadInfo info : ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)) {
+            dump.append(System.lineSeparator())
+                .append('"').append(info.getThreadName()).append("\" ").append(info.getThreadState());
+            if (info.getLockName() != null) {
+                dump.append(" on ").append(info.getLockName());
+            }
+            if (info.getLockOwnerName() != null) {
+                dump.append(" owned by \"").append(info.getLockOwnerName()).append('"');
+            }
+            for (final StackTraceElement frame : info.getStackTrace()) {
+                dump.append(System.lineSeparator()).append("\tat ").append(frame);
+            }
+        }
+        return dump.toString();
     }
 
     @Test

--- a/src/test/java/org/evochora/node/NodeIntegrationTest.java
+++ b/src/test/java/org/evochora/node/NodeIntegrationTest.java
@@ -2,6 +2,7 @@ package org.evochora.node;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -156,10 +157,16 @@ class NodeIntegrationTest {
     void resetServicesToStopped() {
         // This ensures each test starts from a clean, predictable state.
         given().post(BASE_PATH + "/stop").then().statusCode(202);
-        // Allow sufficient time for services to stop, especially during high system load
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
-            given().get(BASE_PATH + "/status").then().body("status", equalTo("STOPPED"))
-        );
+        // The stop runs on the request thread, so every service has already been stopped when the
+        // 202 arrives and the first poll should see STOPPED. The status is named in the failure,
+        // because which one it stopped at is the whole answer: RUNNING means the stop is still
+        // under way, while ERROR means a service thread survived its interrupt and the status will
+        // never become STOPPED, however long this waits.
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            final String status = given().get(BASE_PATH + "/status")
+                .then().extract().path("status");
+            assertThat("pipeline status after /stop", status, equalTo("STOPPED"));
+        });
     }
 
     @Test

--- a/src/test/java/org/evochora/node/processes/http/api/visualizer/OrganismControllerUnitTest.java
+++ b/src/test/java/org/evochora/node/processes/http/api/visualizer/OrganismControllerUnitTest.java
@@ -101,7 +101,7 @@ class OrganismControllerUnitTest {
                     Collections.emptyList(), false, null, Collections.emptyList(),
                     instructions, 0, 0);
 
-            OrganismStaticInfo staticInfo = new OrganismStaticInfo(null, 0L, "prog-1", new int[]{0, 0}, List.of());
+            OrganismStaticInfo staticInfo = new OrganismStaticInfo(null, 0L, "prog-1", new int[]{0, 0}, List.of(), 0);
             OrganismTickDetails details = new OrganismTickDetails(1, 1L, staticInfo, runtimeView);
 
             when(mockDatabase.createReader(any())).thenReturn(mockReader);


### PR DESCRIPTION
## What this fixes

Four defects in the visualizer, found while chasing a false warning.

### 1. "Unknown procedure called at [x|y]" for unmutated descendants

Every newborn gets its LABEL and LABELREF molecules XOR-masked with a random
namespace mask, and the masks compose down the lineage. The view resolved a
procedure's label hash against the artifact without undoing that mask, so from
the second generation on no name matched and every call was reported as
unknown - the opposite of what the message is for, which is to say when the
source view no longer describes what the organism runs.

The composed mask now travels with the organism's static info. `LabelNamespaceMask`
holds the composition rule that `LineageMutationTranslator` carried as three
private copies, and `IOrganismDataReader` derives it in a default method so no
reader can omit it.

### 2. A location register named by a bank-local id

`formatRegisterName` reported a location register by its id within its bank
rather than the id every bank is addressed by, so the displayed name did not
match the operand.

### 3. An instruction record shorter than its operands

The converter silently skipped an operand whose cell was missing. Signature and
length come from the same registration and a read always fills every slot, so a
short record can only be a programming error - it now fails instead of showing
an instruction with fewer operands than it has.

### 4. A genome that changed colour on the first tick step

The view held one genome ancestry map fed from two sources: the closure the
backend delivers, and edges it derived itself from the mutation events of the
selected lineage. The two answer different questions about the same column -
the closure asks which genome a genome arose from, an event reports what its
own parent carried at that one birth - so they disagree, and keyed by genome
hash the derived edges can name each other in a circle. An ancestry pointing in
a circle has no root, and the colour followed whichever genome the traversal
reached first. The derived edges close no gap the backend leaves, so they are
gone.

### 5. A warning that only appeared on an organism switch

The status bar was written before the check that switches the source file, and
that check redraws the view including the status bar.

## Also here

- The wait for a stopped pipeline in `NodeIntegrationTest` now names the status
  it saw and appends all thread stacks, because its failures so far carried
  neither.

## Verification

`./gradlew check` green, 2858 tests. The procedure resolution has a test that
fails on the previous code. The colour behaviour was measured in the running
visualizer: a genome stays at one colour across loading, tick steps, returning
to the first tick and organism switches, where it previously changed on the
first step and kept the new colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lis7Hi2HGy2TsQt8hXvc7b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved label and procedure name resolution for organisms with inherited label transformations.
  - Visualizer annotations now display label and procedure references using the organism’s effective values.
  - Organism details now retain label namespace information for accurate instruction and source views.

- **Bug Fixes**
  - Corrected location-register identification and operand resolution.
  - Missing or unsupported instruction operands now produce clear errors instead of being silently ignored.
  - Prevented execution warnings from being lost during source-view updates.

- **Documentation**
  - Clarified register identifiers, register banks, and procedure-name resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->